### PR TITLE
http: use python3.

### DIFF
--- a/httpd/treatasm.py
+++ b/httpd/treatasm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import re
 import sys
 


### PR DESCRIPTION
Fix compile issue where system don't have python2. I get error below.

```
/bin/sh: line 1: ./treatasm.py: cannot execute: required file not found
make[1]: *** [Makefile:15: httpd.rel] Error 127
```

Debian has python3 a long time so use it.
See https://wiki.debian.org/Python