### PR TITLE
fix: comp. warning 283: function declarator with no prototype.

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -91,7 +91,7 @@ uint8_t parse_short(register uint16_t *n, __xdata uint8_t * __xdata p)
 }
 
 
-void send_not_found()
+void send_not_found(void)
 {
 	slen = strtox(outbuf, "HTTP/1.1 404 Not found\r\nContent-Type: text/html\r\n\r\n");
 	print_string("slen: "); print_short(slen); write_char('\n');

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -367,7 +367,7 @@ void port_l2_learned(void) __banked
 /*
  * Basic L2 configuration such as time to forget an entry
  */
-void port_l2_setup() __banked
+void port_l2_setup(void) __banked
 {
 	print_string("\nport_l2_setup called\n");
 

--- a/rtl837x_port.h
+++ b/rtl837x_port.h
@@ -25,6 +25,6 @@ void vlan_delete(uint16_t vlan) __banked;
 void port_mirror_set(register uint8_t port, __xdata uint16_t rx_pmask, __xdata uint16_t tx_pmask) __banked;
 void port_mirror_del(void) __banked;
 void port_ingress_filter(register uint8_t port, uint8_t type) __banked;
-void port_l2_setup() __banked;
+void port_l2_setup(void) __banked;
 void trunk_set(uint8_t group, uint16_t mask) __banked;
 #endif


### PR DESCRIPTION
Fix compiler warning 283: function declarator with no prototype.