### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+.gitignore
+*.map
+*.rel
+*.rst
+*.sym
+*.asm
+*.bin
+*.ihx
+*.ihex
+*.lst
+*.mem
+*.lk
+html_data.c
+html_data.h
+tools/httpd_sim
+tools/injector
+tools/fileadder


### PR DESCRIPTION
Clean up git noise for now.

I reed in the sdcc manual that you can specify a output build dir.
So that the build artifacts don´t clutter the source tree.