### PR TITLE
Added a simple ram and flash usage by using .mem file.

### DIFF
--- a/rtlplayground.mem
+++ b/rtlplayground.mem
@@ -1,0 +1,29 @@
+Internal RAM layout:
+      0 1 2 3 4 5 6 7 8 9 A B C D E F
+0x00:|0|0|0|0|0|0|0|0|a|a|a|a|a|a|a|a|
+0x10:|c|c|c|d|d|d|d|d|d|d| | | | | | |
+0x20:|B|T|b|b|b|b|b|b|b|b|b|b|b|b|b|b|
+0x30:|b|b|b|b|e|e|e|e|e|e|e|e|f|f|f|f|
+0x40:|f|f|f|f|f|g|g|g|g|g|g|g|g|g|g|g|
+0x50:|g|h|h|h|h|h|h|h|h|h|h|h|h|i|i|i|
+0x60:|i|i|i|i|i|i|i|j|j|j|j|j|j|j|j|j|
+0x70:|j|j|j|j|j|Q|Q|Q|Q|Q|Q|Q|S|S|S|S|
+0x80:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
+0x90:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
+0xa0:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
+0xb0:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
+0xc0:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
+0xd0:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
+0xe0:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
+0xf0:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
+0-3:Reg Banks, T:Bit regs, a-z:Data, B:Bits, Q:Overlay, I:iData, S:Stack, A:Absolute
+
+16 bit mode initial stack starts at: 0x7c (sp set to 0x7b) with 132 bytes available.
+The largest spare internal RAM space starts at 0x1a with 6 bytes available.
+
+Other memory:
+   Name             Start    End      Size     Max     
+   ---------------- -------- -------- -------- --------
+   PAGED EXT. RAM                         0      256   
+   EXTERNAL RAM     0x0001   0x1ad8    6872    16777216
+   ROM/EPROM/FLASH  0x0000   0x1c267  45385    16777216


### PR DESCRIPTION
So we can keep track of ram, stack and flash usage.
In the future we can provide more details like every flash bank usage.

This mem-file is from commit 3392b58.
`rtlplayground.mem` file needs to be commit as well in every PR.


