### PR TITLE
Smaller image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ OBJS = ${SRCS:.c=.rel}
 OBJS += uip/timer.rel uip/uip-fw.rel uip/uip-neighbor.rel uip/uip-split.rel uip/uip.rel uip/uip_arp.rel uip/uiplib.rel httpd/httpd.rel httpd/page_impl.rel
 
 html_data.c html_data.h: html tools
-	tools/fileadder -a -s -b BANK1 -d html -p html_data
+	tools/fileadder -a 458752 -s 524288 -b BANK1 -d html -p html_data
 
 httpd: html_data.h
 
@@ -50,8 +50,8 @@ rtlplayground.ihx:  crtstart.rel $(OBJS)
 	cat $< >> $@
 	truncate --size=16K $@
 	dd if=$< skip=80 bs=1024 >>$@
-	tools/fileadder -s -d config.txt $@
-	tools/fileadder -a -s -d html -p html_data $@
+	tools/fileadder -a 458752 -s 524288 -d config.txt $@
+	tools/fileadder -a 262144 -s 524288 -d html -p html_data $@
 
 .PHONY: clean all $(SUBDIRS)
 .PRECIOUS: %.rel %.ihx .img

--- a/tools/fileadder.c
+++ b/tools/fileadder.c
@@ -39,10 +39,10 @@ const char *argp_program_bug_address = "<git@logicog.de>";
 static char doc[] = "Adds a file or a directory of files into an image";
 static char args_doc[] = "addfile [options] INPUT_IMAGE";
 static struct argp_option options[] = {
-    { "size", 's', "SIZE", OPTION_ARG_OPTIONAL, "Resize image"},
+    { "size", 's', "SIZE", 0, "Resize image"},
     { "output", 'o', "FILE", 0, "Output image file name instead of overwriting input image"},
     { "data", 'd', "FILE", 0, "File or directory to add to image"},
-    { "address", 'a', 0, OPTION_ARG_OPTIONAL, "Address where data is placed, default is 0x1000000 if option is used, otherwise 0x1fd000"},
+    { "address", 'a', "SIZE", 0, "Address where data is placed, default is 0x1000000 if option is used, otherwise 0x1fd000"},
     { "prefix", 'p', "FILE", 0, "Prefix for header and index file generation"},
     { "bank", 'b', "BANKNAME", 0, "Generate #pragma with given bank-name"},
     { 0 }
@@ -57,6 +57,7 @@ struct arguments {
 	char *bank;
 	bool overwrite;
 	bool add_zero;
+	char *args[1];
 };
 
 


### PR DESCRIPTION
This fixes a bug with parsing the command line arguments in fileadder. This is then used to make images in the Makefile with by default 512kB size. Also added is support for parsing the ip, gw and netmask command for reading a config file.