### PR TITLE
Fix bug in usage of CONST segment in banked code. Use #pragma constseg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ $(BUILDDIR)%.rel: $(BUILDDIR)%.asm
 	${ASM} ${AFLAGS} -o $@ $<
 #	mv -f $(addprefix $(basename $^), .lst .rel .sym) .
 
-$(BUILDDIR)rtlplayground.ihx: $(BUILDDIR)crtstart.rel $(OBJS) 
+$(BUILDDIR)rtlplayground.ihx: $(BUILDDIR)crtstart.rel $(OBJS)
 	$(CC) $(CC_FLAGS) -Wl-bHOME=${BOOTLOADER_ADDRESS}  -Wl-bBANK1=0x14000 -Wl-r -o $@ $^
 
 $(BUILDDIR)rtlplayground.img: $(BUILDDIR)rtlplayground.ihx

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -18,6 +18,7 @@
 #include "uip/uip.h"
 
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 extern __xdata uint8_t minPort;
 extern __xdata uint8_t maxPort;

--- a/httpd/Makefile
+++ b/httpd/Makefile
@@ -17,8 +17,6 @@ $(BUILDDIR)%.asm: %.c
 	$(CC) $(CC_FLAGS) -o $@ -c -S $<
 
 $(BUILDDIR)%.rel: $(BUILDDIR)%.asm
-	./treatasm.py $^ >$^.new
-	mv $^.new $^
 	${ASM} ${AFLAGS} -o $@ $^
 
 clean:

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -16,6 +16,7 @@
 #define CMARK_S 6
 
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 extern __code struct f_data f_data[];
 extern __code char * __code mime_strings[];

--- a/rtl837x_phy.c
+++ b/rtl837x_phy.c
@@ -17,6 +17,7 @@
 #include "phy.h"
 
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 extern __code uint16_t bit_mask[16];
 

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -15,6 +15,7 @@
 #include "phy.h"
 
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 extern __code uint8_t * __code hex;
 extern __code uint16_t bit_mask[16];

--- a/tools/fileadder.c
+++ b/tools/fileadder.c
@@ -276,7 +276,7 @@ int main(int argc, char **argv)
 	if (arguments.prefix)
 		ibuf_p += snprintf(&ibuf[ibuf_p], INDEX_SIZE - ibuf_p, "#include \"%s.h\"\n\n", arguments.prefix);
 	if (arguments.bank)
-		ibuf_p += snprintf(&ibuf[ibuf_p], INDEX_SIZE - ibuf_p, "#pragma codeseg %s\n\n", arguments.bank);
+		ibuf_p += snprintf(&ibuf[ibuf_p], INDEX_SIZE - ibuf_p, "#pragma codeseg %s\n#pragma constseg %s\n\n", arguments.bank, arguments.bank);
 	ibuf_p += snprintf(&ibuf[ibuf_p], INDEX_SIZE - ibuf_p, " __code char * __code mime_strings[] = {\n  \"text/html\",\n  \"image/svg+xml\",\n"
 		"  \"image/svg+xml\",\n  \"image/png\",\n  \"text/javascript\",\n  \"text/css\",\n  \"text/plain\"};\n\n");
 	ibuf_p += snprintf(&ibuf[ibuf_p], INDEX_SIZE - ibuf_p, "__code struct f_data f_data[] = {\n");

--- a/uip/psock.c
+++ b/uip/psock.c
@@ -48,6 +48,7 @@
 #define STATE_DATA_SENT 6
 
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 /*
  * Return value of the buffering functions that indicates that a

--- a/uip/timer.c
+++ b/uip/timer.c
@@ -49,6 +49,7 @@
 #include "timer.h"
 
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 /*---------------------------------------------------------------------------*/
 /**

--- a/uip/uip-fw.c
+++ b/uip/uip-fw.c
@@ -60,6 +60,7 @@
 #include "uip-fw.h"
 
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 #include "../rtl837x_common.h"
 

--- a/uip/uip-neighbor.c
+++ b/uip/uip-neighbor.c
@@ -44,7 +44,7 @@
 #include "../rtl837x_common.h"
 
 #pragma codeseg BANK1
-
+#pragma constseg BANK1
 
 #define MAX_TIME 128
 

--- a/uip/uip-split.c
+++ b/uip/uip-split.c
@@ -41,8 +41,8 @@
 #include "uip-fw.h"
 #include "uip_arch.h"
 
-
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 #define BUF ((__xdata struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
 

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -84,6 +84,7 @@
 #include "uip_arch.h"
 
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 #if UIP_CONF_IPV6
 #include "uip-neighbor.h"

--- a/uip/uip_arp.c
+++ b/uip/uip_arp.c
@@ -64,6 +64,7 @@
 #include "../rtl837x_common.h"
 
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 struct arp_hdr_i {
   struct uip_eth_hdr ethhdr;

--- a/uip/uiplib.c
+++ b/uip/uiplib.c
@@ -38,6 +38,7 @@
 #include "uiplib.h"
 
 #pragma codeseg BANK1
+#pragma constseg BANK1
 
 /*-----------------------------------------------------------------------------------*/
 unsigned char


### PR DESCRIPTION
What was considered a bug is in fact a feature: Constants that are defined after a #pragma codeseg ended up in BANK0, which was quickly running out of space. While hunting this "bug" down in sdcc, I found out that it is necessary to explicitly also put constants into the same bank as the code. This is now being done and reduces the size of BANK0 from 0x3b00 to 0x3500.