### PR TITLE
html: firmware selection: limit extension only to .bin

### DIFF
--- a/html/update.html
+++ b/html/update.html
@@ -11,7 +11,7 @@
     <h1>Firmware Update</h1>
     <form enctype="multipart/form-data" action="/upload" method="POST">
     <input type="hidden" name="MAX_FILE_SIZE" value="1000000" />
-      Choose a firmware update file to upload: <input name="uploadedfile" type="file" /><br />
+      Choose a firmware update file to upload: <input name="uploadedfile" type="file" accept=".bin" /><br />
     <input type="submit" value="Upload File" />
     </form>
     <script src="/navigation.js"></script>


### PR DESCRIPTION
This makes it quicker to select firmware image from the output directory.

You can still select at File type "All Files" if the extension is different.

<img width="600" height="466" alt="Screenshot_20251030_210804" src="https://github.com/user-attachments/assets/26954590-63df-4217-bfec-e7cf84a3bc7f" />
