### PR TITLE
De-Magic I2C configuration for SFP-EEPROM reads

### DIFF
--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -5,7 +5,11 @@
 #include <stdint.h>
 
 // This has to be set to the number of SFP+ ports, i.e. 1 or 2
-#define NSFP 2
+#define NSFP		2
+// SCL and SDA pin numbers for SFP cage 0 and SFP cage 1
+#define SCL_PIN		3
+#define SDA_PIN_0	4
+#define SDA_PIN_1	3
 
 // Define Port-masks for 9-port devices and 6-port devices
 #define PMASK_9		0x1ff

--- a/rtl837x_regs.h
+++ b/rtl837x_regs.h
@@ -66,9 +66,13 @@
 /*
  * I2C controller
  */
-#define RTL837X_REG_I2C_CTRL	0x0418
-#define RTL837X_REG_I2C_IN	0x0420
-#define RTL837X_REG_I2C_OUT	0x0424
+#define RTL837X_REG_I2C_MST_IF_CTRL	0x0414
+#define RTL837X_REG_I2C_CTRL		0x0418
+#define I2C_DEV_ADDR			3
+#define I2C_MEM_ADDR_WIDTH		20
+#define RTL837X_REG_I2C_CTRL2		0x041c
+#define RTL837X_REG_I2C_IN		0x0420
+#define RTL837X_REG_I2C_OUT		0x0424
 
 /*
  * NIC Related registers

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -725,11 +725,11 @@ uint8_t sfp_read_reg(uint8_t slot, uint8_t reg)
 {
 	if (slot == 0) {
 		reg_read_m(RTL837X_REG_I2C_CTRL);
-		sfr_mask_data(1, 0xff, 0x72);
+		sfr_mask_data(1, 0xfc, SCL_PIN << 5 | SDA_PIN_0 << 2);
 		reg_write_m(RTL837X_REG_I2C_CTRL);
 	} else {
 		reg_read_m(RTL837X_REG_I2C_CTRL);
-		sfr_mask_data(1, 0xff, 0x6e);
+		sfr_mask_data(1, 0xfc, SCL_PIN << 5 | SDA_PIN_1 << 2);
 		reg_write_m(RTL837X_REG_I2C_CTRL);
 	}
 
@@ -1650,9 +1650,10 @@ void setup_serial(void)
 
 void setup_i2c(void)
 {
-	REG_SET(0x0414, 0);
-	REG_SET(0x0418, 0x00100280);
-	REG_SET(0x041c, 0);
+	REG_SET(RTL837X_REG_I2C_MST_IF_CTRL, 0);
+	// Configure SFP EEPROM address (0x50) as I2C device address
+	REG_SET(RTL837X_REG_I2C_CTRL, 0x1L << I2C_MEM_ADDR_WIDTH | 0x50 << I2C_DEV_ADDR);
+	REG_SET(RTL837X_REG_I2C_CTRL2, 0);
 
 	// HW Control register, enable I2C?
 	reg_read_m(RTL837X_PIN_MUX_1);


### PR DESCRIPTION
De-magic register configuration around I2C reads to the SFP EEPROMS.