### PR TITLE
Added software version + git short hash string to firmware.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 output/
 html_data.c
 html_data.h
+version.h
 tools/httpd_sim
 tools/injector
 tools/fileadder

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BOOTLOADER_ADDRESS=0x100
 
+VERSION=0.1.0
 IMAGESIZE = 524288
 CONFIG_LOCATION = 458752
 HTML_LOCATION = 262144
@@ -13,8 +14,9 @@ SUBDIRS := tools uip httpd
 SUBDIRSCLEAN=$(addsuffix clean,$(SUBDIRS))
 
 BUILDDIR = output/
+VERSION_HEADER := version.h
 
-all: create_build_dir $(SUBDIRS) $(BUILDDIR)rtlplayground.bin
+all: create_build_dir $(VERSION_HEADER) $(SUBDIRS) $(BUILDDIR)rtlplayground.bin
 
 create_build_dir:
 	mkdir -p $(BUILDDIR)
@@ -26,6 +28,12 @@ OBJS += uip/$(BUILDDIR)/timer.rel uip/$(BUILDDIR)/uip-fw.rel uip/$(BUILDDIR)/uip
 html_data.c html_data.h: html tools
 	tools/$(BUILDDIR)fileadder -a $(HTML_LOCATION) -s $(IMAGESIZE) -b BANK1 -d html -p html_data
 
+$(VERSION_HEADER):
+	@echo "#ifndef VERSION_H" > $(VERSION_HEADER)
+	@echo "#define VERSION_H" >> $(VERSION_HEADER)
+	@echo "#define VERSION_SW \"v$(VERSION)-g$(shell git rev-parse --short HEAD)\"" >> $(VERSION_HEADER)
+	@echo "#endif" >> $(VERSION_HEADER)
+
 httpd: html_data.h
 
 $(SUBDIRS):
@@ -34,7 +42,7 @@ $(SUBDIRS):
 clean:
 	-make -C uip clean
 	-make -C httpd clean
-	-rm html_data.c html_data.h
+	-rm html_data.c html_data.h $(VERSION_HEADER)
 	-rm -r $(BUILDDIR)
 
 $(BUILDDIR)crtstart.rel: crtstart.asm

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -16,6 +16,7 @@
 #include "rtl837x_sfr.h"
 #include "rtl837x_stp.h"
 #include "uip/uip.h"
+#include "version.h"
 
 #pragma codeseg BANK1
 #pragma constseg BANK1
@@ -490,6 +491,13 @@ void print_gpio_status(void) {
 	}
 }
 
+// Show software version
+void print_sw_version(void) __banked {
+	print_string("Software version: ");
+	print_string(VERSION_SW);
+	write_char('\n');
+}
+
 
 // Identify command
 void cmd_parser(void) __banked
@@ -694,6 +702,9 @@ void cmd_parser(void) __banked
 				else
 					port_eee_status_all();
 			}
+		}
+		if (cmd_compare(0, "version")) {
+			print_sw_version();
 		}
 	}
 }

--- a/cmd_parser.h
+++ b/cmd_parser.h
@@ -11,4 +11,5 @@ extern __xdata uint8_t cmd_available;
 uint8_t cmd_tokenize(void) __banked;
 void cmd_parser(void) __banked;
 void execute_config(void) __banked;
+void print_sw_version(void) __banked;
 #endif

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -8,6 +8,7 @@
 #include "../html_data.h"
 #include <stdint.h>
 #include "../phy.h"
+#include "../version.h"
 
 #pragma codeseg BANK1
 #pragma constseg BANK1
@@ -169,8 +170,9 @@ void send_basic_info(void)
 	byte_to_html(uip_ethaddr.addr[3]); char_to_html(':');
 	byte_to_html(uip_ethaddr.addr[4]); char_to_html(':');
 	byte_to_html(uip_ethaddr.addr[5]);
-	slen += strtox(outbuf + slen, "\",\"sw_ver\":\"v0.1-ge4c48586\",\"hw_ver\":\"SWGT024-V2.0\"}");
-	// slen += strtox(outbuf + slen, "\"}");
+	slen += strtox(outbuf + slen, "\",\"sw_ver\":\"");
+	slen += strtox(outbuf + slen, VERSION_SW);
+	slen += strtox(outbuf + slen, "\",\"hw_ver\":\"SWGT024-V2.0\"}");
 }
 
 

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1707,6 +1707,9 @@ void bootloader(void)
 		print_string("RTL8372\n");
 	}
 
+	// Print SW version
+	print_sw_version();
+
 	print_string("\nStarting up...\n");
 	print_string("  Flash controller\n");
 	flash_init(0);

--- a/tools/httpd_sim.c
+++ b/tools/httpd_sim.c
@@ -8,6 +8,7 @@
 #include "httpd_sim.h"
 #include <json.h>
 #include <signal.h>
+#include "../version.h"
 
 #define PORTS 6
 time_t last_called;
@@ -71,7 +72,7 @@ void send_basic_info(int socket)
 {
 	char *response = "HTTP/1.1 200 OK\r\n"
 		    "Content-Type: application/json; charset=UTF-8\r\n\r\n"
-			"{\"ip_address\":\"192.168.10.247\",\"ip_gateway\":\"192.168.2.22\",\"ip_netmask\":\"255.255.255.0\",\"mac_address\":\"1c:2a:a3:23:00:02\",\"sw_ver\":\"v0.1-ge4c48586\",\"hw_ver\":\"SWGT024-V2.0\"}";
+			"{\"ip_address\":\"192.168.10.247\",\"ip_gateway\":\"192.168.2.22\",\"ip_netmask\":\"255.255.255.0\",\"mac_address\":\"1c:2a:a3:23:00:02\",\"sw_ver\":\"" VERSION_SW "\",\"hw_ver\":\"SWGT024-V2.0\"}";
 	write(socket, response, strlen(response));
 }
 


### PR DESCRIPTION
The Makefile has the version number and generates a version.h which has VERSION_SW define that looks like "v<VERSION>-g<GIT_SHORT_HASH>".

Software version is shown at boot in the serial console.
And shown with command: `version`.

It can also be requested via `information.json`, which is also displayed on main site.
```
{
    "ip_address": "192.168.10.247",
    "ip_gateway": "192.168.10.1",
    "ip_netmask": "255.255.255.0",
    "mac_address": "1c:2a:a3:23:00:02",
    "sw_ver": "v0.1.0-gd48235f",
    "hw_ver": "SWGT024-V2.0"
}
```
Both visable on the real device and simulator.

<img width="719" height="520" alt="Screenshot_20251126_230728" src="https://github.com/user-attachments/assets/3529bf04-ee6c-4d13-b826-47bb3157dd31" />

