### PR TITLE
[WIP] Move sfr_data to pdata or sram.

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -27,7 +27,7 @@ extern __xdata uint8_t stpEnabled;
 extern __code uint8_t log_to_phys_port[9];
 
 extern volatile __xdata uint32_t ticks;
-extern volatile __pdata uint8_t sfr_data[4];
+extern volatile __data uint8_t sfr_data[4];
 
 extern __code uint8_t * __code greeting;
 extern __code uint8_t * __code hex;

--- a/rtl837x_igmp.c
+++ b/rtl837x_igmp.c
@@ -23,7 +23,7 @@ extern __code struct machine machine;
 #pragma constseg BANK1
 
 extern __xdata uint8_t cpuPort;
-extern __pdata uint8_t sfr_data[4];
+extern __data uint8_t sfr_data[4];
 
 extern __xdata uint8_t uip_buf[UIP_CONF_BUFFER_SIZE + 2];
 

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -21,7 +21,7 @@
 extern __code uint8_t * __code hex;
 extern __code uint16_t bit_mask[16];
 extern __code struct machine machine;
-extern __pdata uint8_t sfr_data[4];
+extern __data uint8_t sfr_data[4];
 extern __xdata uint16_t vlan_ptr;
 extern __xdata uint8_t vlan_names[VLAN_NAMES_SIZE];
 

--- a/rtl837x_stp.c
+++ b/rtl837x_stp.c
@@ -15,7 +15,7 @@
 #include "machine.h"
 
 extern __code struct machine machine;
-extern __pdata uint8_t sfr_data[4];
+extern __data uint8_t sfr_data[4];
 
 extern __code struct uip_eth_addr uip_ethaddr;
 

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -71,7 +71,7 @@ __xdata uint8_t stp_clock;
 // Buffer for serial input, SBUF_SIZE must be power of 2 < 256
 __xdata volatile uint8_t sbuf_ptr;
 __xdata uint8_t sbuf[SBUF_SIZE];
-__pdata uint8_t sfr_data[4];
+__data uint8_t sfr_data[4];
 
 extern __xdata uint8_t gpio_last_value[8];
 
@@ -98,7 +98,7 @@ __code uint16_t bit_mask[16] = {
 
 
 __xdata uint8_t was_offline;
-__pdata uint8_t linkbits_last[4];
+__data uint8_t linkbits_last[4];
 __xdata uint8_t linkbits_last_p89;
 __xdata uint8_t sfp_pins_last;
 
@@ -581,7 +581,7 @@ void print_sds_reg(uint8_t sds_id, uint8_t page, uint8_t reg)
 }
 
 
-char cmp_4(__pdata uint8_t a[], __pdata uint8_t b[])
+char cmp_4(__data uint8_t * a, __data uint8_t * b)
 {
 	for (uint8_t i = 0; i < 4; i++) {
 		if (a[i] == b[i])
@@ -594,7 +594,7 @@ char cmp_4(__pdata uint8_t a[], __pdata uint8_t b[])
 	return 0;
 }
 
-void cpy_4(__pdata uint8_t dest[], __pdata uint8_t source[])
+void cpy_4(__data uint8_t * dest, __data uint8_t * source)
 {
 	for (uint8_t i = 0; i < 4; i++)
 		dest[i] = source[i];


### PR DESCRIPTION
I am working on SIPHASH were I need a large memory block of 32 bytes.
But I want to access it easily.
I know you can access lower part XDATA via a single register using the instruction `MOVX @Ri, A`. 
This is called Paged Memory??. Just use `__pdata` to define a variable.
Not sure if paging is controllable.

Because we are using `sfr_data` a lot, it make sense to make it faster to access.
I made a quick test to move `sfr_data` to `pdata`.
Because of some function I also needed to move `linkbits_last`.
See first commit.
As a result it reduced the code size with 350 bytes.
Most of these bytes, I assume, are used to load in the DPTR of calculate it.

Second commit is move `sfr_data` and `linkbits_last` to sram.
I think it make sense to use some extra sram to access sfr_data faster.
As a result it reduced the code size with 650 bytes from the original xdata code.

diff between the two `.mem`-files.
<img width="715" height="172" alt="Screenshot_20251215_232627" src="https://github.com/user-attachments/assets/0668ccd9-e6c6-4acb-88db-10fc24d351f9" />

So I think we can optimize more things by moving them into `__pdata`.

And/Or define a large scrats-memory block in pdata, which I may need for my SIPHASH.
Which can also be used by other code.