### PR TITLE
Add rounding to baud rate calculation

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1649,8 +1649,8 @@ void setup_serial(void)
 
 	// The RCAP2 registers contain the high/low byte that is loaded into
 	// timer2 when T2 overflows to 0x10000
-	RCAP2H = (0x10000 - (CLOCK_HZ / SERIAL_BAUD_RATE / 32)) >> 8;
-	RCAP2L = (0x10000 - (CLOCK_HZ / SERIAL_BAUD_RATE / 32)) % 0xff;
+	RCAP2H = (0x10000 - ((CLOCK_HZ / SERIAL_BAUD_RATE + 16) / 32)) >> 8;
+	RCAP2L = (0x10000 - ((CLOCK_HZ / SERIAL_BAUD_RATE + 16) / 32)) % 0xff;
 
 	PCON |= 0x80; // Double the Baud Rate
 


### PR DESCRIPTION
Without rounding:
- Divisor: 33 = (125000000 / 115200 / 32)
- RCAP2 value: 65503
- Actual baud rate: 118371 = (125000000 / 32 / 33)
- Error: 2.75%

With rounding:
- Divisor: 34 = ((125000000 / 115200 + 16) / 32)
- RCAP2 value: 65502
- Actual baud rate: 114889 = (125000000 / 32 / 34)
- Error: 0.27%

Should fix https://github.com/logicog/RTLPlayground/issues/48