### PR TITLE
Move SYS_TICK to Timer2 and SERIAL baudrate gen to Timer1.

### DIFF
--- a/crtstart.asm
+++ b/crtstart.asm
@@ -16,12 +16,12 @@ __interrupt_vect:
 	.ds     5
 	ljmp	_isr_ext1	; 0x13
 	.ds     5
-	reti
+	reti			; 0x1b TIMER 1 IRQ
 	.ds     7
  	ljmp    _isr_serial	; 0x23
 	.ds     5
-	reti			; 0x2b TIMER 2 IRQ
-	.ds     7
+	ljmp	_isr_timer2	; 0x2b TIMER 2 IRQ
+	.ds     5
 	reti			; 0x33 NOT used by DW8051
 	.ds     7
 	reti			; 0x3b Serial port 1 RX/TX IRQ

--- a/installer/installer.c
+++ b/installer/installer.c
@@ -11,7 +11,6 @@
 #include "../rtl837x_sfr.h"
 #include "../rtl837x_regs.h"
 
-#define SYS_TICK_HZ 100
 #define SERIAL_BAUD_RATE 57600
 #define CLOCK_HZ 125000000
 
@@ -26,10 +25,6 @@
 #define CLOCK_DIV 0
 #endif
 
-volatile __xdata uint32_t ticks;
-volatile __xdata uint8_t sec_counter;
-volatile __xdata uint16_t sleep_ticks;
-
 // We buffer 1 sector as this is also the erase size
 __xdata uint8_t buffer[0x1000];
 __xdata uint8_t dio_enabled;
@@ -38,16 +33,6 @@ __code uint8_t * __code hex = "0123456789abcdef";
 
 void isr_timer0(void) __interrupt(1)
 {
-	TR0 = 0;		// Stop timer 0
-	TH0 = (0x10000 - (CLOCK_HZ / SYS_TICK_HZ / 32)) >> 8;
-	TL0 = (0x10000 - (CLOCK_HZ / SYS_TICK_HZ / 32)) % 0xff;
-
-	ticks++;
-	if (sleep_ticks > 0)
-		sleep_ticks--;
-	sec_counter++;
-
-	TR0 = 1;		// Re-start timer 0
 }
 
 

--- a/rtl837x_sfr.h
+++ b/rtl837x_sfr.h
@@ -40,11 +40,6 @@ __sfr __at(0x91) EXIF;
 __sfr __at(0xf8) EIP;
 __sbit __at(0xf9) PX3;
 
-/* SFR control registers for serial communication */
-__sfr __at(0xc8) T2CON;
-__sfr __at(0xca) RCAP2L;
-__sfr __at(0xcb) RCAP2H;
-
 /* SFR Bank control register: 0x0-3f. A value of 0 is bank 1 */
 __sfr __at(0x96) PSBANK;
 // SFR used to store return bank for trampoline
@@ -101,3 +96,15 @@ __sfr __at(0xb6) SFR_NIC_RING_H;
 /* Standard 8051 sfr */
 // Timer 0 value
 __sfr16 __at(0x8c8a) T0_U16;
+
+// Timer 1 enable interrupt
+__sbit __at(0xad) ET2;
+
+// Timer 2
+__sfr __at(0xcc) TL2;
+__sfr __at(0xcd) TH2;
+__sfr16 __at(0xcdcc) T2_U16;
+__sfr __at(0xc8) T2CON;
+__sfr __at(0xca) RCAP2L;
+__sfr __at(0xcb) RCAP2H;
+__sfr16 __at(0xcbca) RCAP2_U16;

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -28,6 +28,7 @@ void crc16(__xdata uint8_t *v) __naked;
 // Upload Firmware to 1M
 #define FIRMWARE_UPLOAD_START 0x100000
 
+// See setup_serial_timer1() for valid baudrate settings!
 #define SERIAL_BAUD_RATE 115200
 
 /* All RTL839x switches have an external 25MHz Oscillator,
@@ -1662,25 +1663,48 @@ void init_smi(void)
 }
 
 
-/* Set up serial port 0 using Timer 2 with an external trigger
- * as baud generator.
- * The external clock generator uses a crystal at 25MHz.
+/* Set up serial port 0 using Timer 1 as baudrate generator.
+ * For x Bd these settings are needed, see table below.
+ * NOTE: Settings only valid for F_SYS = 125 MHz!
+ * |   Wanted |       | TMR | F_SYS |      |   Actual |        |
+ * | baudrate | SMOD0 | DIV |   DIV |  TH1 | baudrate |  Error |
+ * | -------- | ----- | --- | ----- | ---- | -------- | ------ |
+ * |     1200 |   0   |  12 |   255 | 0x01 |   1276.6 |  6.00% |
+ * |     2400 |   0   |  12 |   136 | 0x78 |   2393.5 | −0.27% |
+ * |     4800 |   0   |   4 |   203 | 0x35 |   4810.7 |  0.22% |
+ * |     9600 |   1   |   4 |   203 | 0x35 |   9621.3 |  0.22% |
+ * |    14400 |   1   |   4 |   136 | 0x78 |  14361.2 | −0.27% |
+ * |    19200 |   1   |   4 |   102 | 0x9a |  19148.3 | −0.27% |
+ * |    38400 |   1   |   4 |    51 | 0xcd |  38296.6 | −0.27% |
+ * |    57600 |   1   |   4 |    34 | 0xde |  57444.9 | −0.27% |
+ * |   115200 |   1   |   4 |    17 | 0xef | 114889.7 | −0.27% |
  */
-void setup_serial(void)
+#if CLOCK_HZ != 125000000
+#warning "SERIAL 0 baudrate setting may only valid for F_CPU = 125 MHz!"
+#endif
+void setup_serial_timer1(void)
 {
-	IE = 0;
+	// Timer 1: Mode 2: automatic reload
+	TMOD &= 0x0F;
+	TMOD |= 0xA0; // Timer1: GATE, Mode2: Timer, 8-bit with auto-reload
+	CKCON |= 0x10; // Timer1 clock divider: F_SYS / 4: T2M = 1, Timer 1 uses clk/4
 
-	T2CON = 0x34; // Enable RCLK/TCLK (serial transmit/receive clock for T2), TR2 (Timer 2 RUN), disable CP/RL2 (bit 0)
-	SCON = 0x50;  // Mode = 1: ASYNC 8N1 with T2 as baud-rate generator, REN_0 Receive enable
+	PCON |= 0x80; // SMOD0 = 1; Double the Baud Rate, don't divide Timer 1 Overflag signal.
 
-	// The RCAP2 registers contain the high/low byte that is loaded into
-	// timer2 when T2 overflows to 0x10000
-	RCAP2H = (0x10000 - ((CLOCK_HZ / SERIAL_BAUD_RATE + 16) / 32)) >> 8;
-	RCAP2L = (0x10000 - ((CLOCK_HZ / SERIAL_BAUD_RATE + 16) / 32)) % 0xff;
+	SCON  = 0x50;  // Mode = 1: ASYNC 8N1 with Timer 2 as baud-rate generator, REN_0 Receive enable
 
-	PCON |= 0x80; // Double the Baud Rate
+	/* The TH1 register contain the reload value, timer1 when T1 overflows to 0x100.
+	 * NOTE: compiler computs the wrong value. 0xF0 is calculated but 0xEF is the right value for 115200.
+	 * Also https://www.keil.com/products/c51/baudrate.asp confirms this.
+	 * Added 32 before div by 64 to make sure rounding is correct so that the results are right.
+	 *
+	 * TH1 = 0x100 - (2^SMOD0 * F_SYS) / ( TMR1_DIV / BAUDRATE * 32)
+	 */
+	TH1 = (0x100 - (((CLOCK_HZ / SERIAL_BAUD_RATE) + 32) / (4 * 16))) & 0xff;
 
-	SCON = 0x50;
+	TCON |= 0x40;	// Start timer 1
+
+	ET1 = 0; // Timer1 Interrupt is NOT wanted!
 	TI = 1;
 	RI = 0;
 
@@ -1726,7 +1750,7 @@ void bootloader(void)
 	// HW setup, serial, timer, external IRQs
 	setup_clock();
 	setup_timer2();
-	setup_serial();
+	setup_serial_timer1();
 	setup_external_irqs();
 
 	EA = 1; // Enable global interrupt

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -121,7 +121,7 @@ __xdata char sfp_module_vendor[2][17];
 __xdata char sfp_module_model[2][17];
 __xdata char sfp_module_serial[2][17];
 __xdata uint8_t sfp_options[2];
-__sbit tx_buf_empty = 1;
+__sbit tx_buf_empty;
 
 #define ETHERTYPE_OFFSET (12 + VLAN_TAG_SIZE + RTL_TAG_SIZE)
 
@@ -1712,6 +1712,8 @@ void setup_serial_timer1(void)
 	ET1 = 0; // Timer1 Interrupt is NOT wanted!
 	TI = 0; // Clear TI-interrupt flag
 	RI = 0; // Clear RI-interrupt flag
+
+	tx_buf_empty = 1; // Set tx `serial buffer is empty`-software flag.
 
 	ES = 1; // Enable serial IRQ
 }


### PR DESCRIPTION
With PR #64 we are still running slow.

This has two reasons.
1. Creating a time gap while reprogramming TIMER0.
Reprogramming of TIMER0 takes x number of cpu instructions/cycles.
But every instruction cost us 4 F_SYS cycles and the TIMER0 ticks every 12 F_SYS cycles. So we are creating a gap that TIMER0 could have counted x number of ticks.
Every 3 instruction cycle TIMER0 ticks too. Many instructions take 2 or more instruction cycles.
This gap time can be fixed with, we have to manual count the instruction cycles between after the timer is disabled and after the timer is enabled. Because the compiler can do what he wants, this is not guaranteed to be fix. So writing the reprogramming routine in assemble gives us a fix gap-time.
2. Interrupt latency.
We assume that the interrupt is called directly after the TIMER0 overflow flag is set.
But this is not the case. It depends on what the CPU is doing and interrupt-priority TIMER0 has. So the compiler add a lot of prologue code before the reprogram-part which also adds extra unknown latency.

Both issues could be fixed with better IRQ code.

@ranma suggested that Timer 1 could be used to generate baudrate for SERIAL 0.

In fact Timer1, in 8-bit auto-reload, can be programmed to have the same accuracy and deviation as Timer2, up to 115200 at F_SYS = 125 Mhz, see table below.

<img width="780" height="524" alt="Screenshot_20260104_115434" src="https://github.com/user-attachments/assets/53fa3238-6aa9-42a9-896b-e048cbafec37" />

Timer 2 can be used for the SYS_TICKS, advantage is that Timer 2 auto-reload function can be used. So no software reprogramming on every overflow/sys_tick.
Using Timer 2 as sys_tick timer doesn't have any advantages/disadvantages other then the auto-reload function. The timer resolution/clock settings are the same.

Changes made:
1. Move SERIAL 0 baudrate generator to TIMER 1.
2. Move SYS_TICK to TIMER 2.

While doing this, another bug popped-up.
Serial code was misusing the TI-flag.
Which caused IRQ-storm and starvation on the other lower priority interrupts. This was not notices before because Timer 0 has a high priority then serial interrupt.

Also updated the `installer`-code
1. Remove the unused SYS_TICK-code
2. Move SERIAL 0 baudrate generator to TIMER 1.

Installer don´t misuse the TI-flag because all interrupts are disabled.
So everything is poll-based.

## Old results when TIMER 0 IRQ is compensating for latency and reprogram-time.

This problem can simply be resolved by adding the current timer value to the number of ticks we need.

I first tried it in C see 43ba1388e76da69aa05be0225fae82c65ef0c0f7 which is great.
But as mentioned above, the compiler to through more code inside this function.
So we have to write it in assembly.

<img width="1025" height="241" alt="Screenshot_20251228_185540" src="https://github.com/user-attachments/assets/d6c84204-8741-483a-a277-f4fed018fd0a" />

First assembly results.
For now as good, see what happens over night.

<img width="1024" height="157" alt="Screenshot_20251228_192533" src="https://github.com/user-attachments/assets/c1c6a56b-ddf5-4b45-b9ae-9bbac29b5a9d" />


Problems: SDCC, Just using `__asm("");` is enough to hit this error
```
?ASlink-Warning-Undefined Global 'sdcc_atomic_exchange_rollback_start' referenced by module ''

?ASlink-Warning-Undefined Global 'sdcc_atomic_exchange_rollback_end' referenced by module ''
```

Looking for `sdcc_atomic_exchange_rollback_start` but found no hits on Google nor DDG.

I made a hack to make it compile and run see 874f471cf9b302df6b1fab5905155bbb3e361f8a.
But looking at the assembly code of `_isr_timer0` and it is way too big for a `200 Hz` routine!

@ranma any idea what this can be?

@logicog and @ranma please test this code for a few days.

Let see if we can resolve the compiler and size issue.