### PR TITLE
SWGT024_V2_0: Fix .phys_to_log_port, sfp-ports have to be swapped.

### DIFF
--- a/machine.c
+++ b/machine.c
@@ -58,7 +58,7 @@ __code const struct machine machine = {
 	.max_port = 8,
 	.n_sfp = 2,
 	.log_to_phys_port = {0, 0, 0, 6, 1, 2, 3, 4, 5},
-	.phys_to_log_port = {4, 5, 6, 7, 3, 8, 0, 0, 0},
+	.phys_to_log_port = {4, 5, 6, 7, 8, 3, 0, 0, 0},
 	.is_sfp= {0, 0, 0, 2, 0, 0, 0, 0, 1},
 	// Left SFP port (J4)
 	.sfp_port[0].pin_detect = 30,


### PR DESCRIPTION
On SWGT024_V2_0, the SFP ports are arranged differently.
The port mapping should also reflect this.

Found while testing #78.