### PR TITLE
version: Also show the hardware profile.

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -688,6 +688,8 @@ void print_gpio_status(void) {
 void print_sw_version(void) __banked {
 	print_string("Software version: ");
 	print_string(VERSION_SW);
+	print_string("\nHardware: ");
+	print_string(machine.machine_name);
 	write_char('\n');
 }
 


### PR DESCRIPTION
Also show the hardware profile at boot and also when using `ver`-command.

```
> ver
Software version: v0.1.0-gb9a8ffa
Hardware: SWGT024 V2.0
```