### PR TITLE
Add support for management VLAN

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -42,6 +42,7 @@ extern __xdata struct dhcp_state dhcp_state;
 
 __xdata uint8_t vlan_names[VLAN_NAMES_SIZE];
 __xdata uint16_t vlan_ptr;
+extern __xdata uint16_t management_vlan;
 __xdata uint8_t gpio_last_value[8] = { 0 };
 
 // Temporatly for str to hex convertion value.
@@ -289,16 +290,20 @@ void parse_vlan(void)
 			vlan_delete(vlan);
 			return;
 		}
+		if (cmd_words_b[2] > 0 && cmd_compare(2, "mgmt")) {
+			management_vlan = vlan;
+			if (!vlan) 
+				print_string("Management VLAN disabled\n");
+			else
+				print_string("Management VLAN set to "); print_short(management_vlan); write_char('\n');
+			return;
+		}
 		uint8_t w = 2;
-		write_char('#');
-		print_byte(cmd_words_b[w] );
-		write_char('#'); write_char(cmd_buffer[cmd_words_b[w]]);
 		if (cmd_words_b[w] > 0 && isletter(cmd_buffer[cmd_words_b[w]])) {
 			register uint8_t i = 0;
 			vlan_names[vlan_ptr++] = hex[(vlan >> 8) & 0xf];
 			vlan_names[vlan_ptr++] = hex[(vlan >> 4) & 0xf] ;
 			vlan_names[vlan_ptr++] = hex[vlan & 0xf];
-			print_string("COPYING: >");
 			while(cmd_buffer[cmd_words_b[w] + i] != ' ') {
 				write_char(cmd_buffer[cmd_words_b[w] + i]);
 				vlan_names[vlan_ptr++] = cmd_buffer[cmd_words_b[w] + i++];

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -105,6 +105,7 @@ __xdata uint8_t rx_headers[16]; // Packet header(s) on RX
 __xdata uint8_t uip_buf[UIP_CONF_BUFFER_SIZE+2];
 
 __xdata uint16_t rx_packet_vlan;
+__xdata uint16_t management_vlan;
 __xdata uint8_t tx_seq;
 
 __xdata uint8_t stpEnabled;
@@ -115,7 +116,6 @@ __code uint16_t bit_mask[16] = {
 };
 
 
-__xdata uint8_t was_offline;
 __xdata uint8_t linkbits_last[4];
 __xdata uint8_t linkbits_last_p89;
 __xdata uint8_t sfp_pins_last;
@@ -921,12 +921,14 @@ void handle_rx(void)
 			    tcpip_output();
 			}
 		} else if (uip_buf[ETHERTYPE_OFFSET] == 0x08 && uip_buf[ETHERTYPE_OFFSET + 1] == 0x00) { // TCP?
-			uip_arp_ipin();	// Learn MAC addresses in TCP packets
-			uip_input();
-			if (uip_len) {
-				// Add ethernet frame
-				uip_arp_out();
-				tcpip_output();
+			if (!management_vlan || management_vlan == rx_packet_vlan) {
+				uip_arp_ipin();	// Learn MAC addresses in TCP packets
+				uip_input();
+				if (uip_len) {
+					// Add ethernet frame
+					uip_arp_out();
+					tcpip_output();
+				}
 			}
 		} else {
 #ifdef RXTXDBG
@@ -1950,7 +1952,7 @@ void bootloader(void)
 	uip_arp_init();
 	httpd_init();
 
-	was_offline = 1;
+	management_vlan = 0; // Disabled
 
 	setup_i2c();
 


### PR DESCRIPTION
This adds support for the verification of a mangement vlan. When enabled, then the switch's CPU will not listen to any packets that are not tagged with the respective VLAN tag.
On the command line this is enabled by setting:
```
> vlan <vlan> mgmt
```
Setting the vlan ID of the management VLAN to 0 or 1 disables the mangement VLAN function.

The functionality can be tested by running on an attached PC ping to the switch. After powering up, the switch will reply to the pings.
Now:
```
> vlan 2 mgmt
Management VLAN set to 0x0002

========= ping no longer gets replies ===========

> vlan 2 1t

vlan_create called
vlan: 0x0002, members: 0x0210, tagged: 0x0210
vlan_create done 

> pvid 1 2

port_pvid_set called 
========= ping works again ===========

> vlan 0 mgmt
Management VLAN disabled

========= ping continues to work ===========
```