### PR TITLE
Enable SFP GPIO pins setup

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -2068,6 +2068,7 @@ void bootloader(void)
 	management_vlan = 0; // Disabled
 
 	setup_i2c();
+	setup_sfp_gpio();
 
 	print_string(greeting);
 


### PR DESCRIPTION
Previous changes addded initialization rotine, which was never called.

Looks like, I've lost crucial change somewhere in re-base process... Had it on testing branch, but never added to PR.