### PR TITLE
Fix MACHINE_KP_9000_6XHML_X2: swap SFP-ports remove unnecessary LED-MUX

### DIFF
--- a/machine.c
+++ b/machine.c
@@ -13,12 +13,14 @@ __code const struct machine machine = {
 	.n_sfp = 2,
 	.log_to_phys_port = {0, 0, 0, 5, 1, 2, 3, 4, 6},
 	.phys_to_log_port = {4, 5, 6, 7, 3, 8, 0, 0, 0},
-	.is_sfp = {0, 0, 0, 2, 0, 0, 0, 0, 1},
+	.is_sfp = {0, 0, 0, 1, 0, 0, 0, 0, 2},
+	// Left SFP port (5)
 	.sfp_port[0].pin_detect = GPIO50_I2C_SCL2_UART1_TX,
 	.sfp_port[0].pin_los = GPIO10_LED10,
 	.sfp_port[0].pin_tx_disable = GPIO_NA,
 	.sfp_port[0].sds = 0,
 	.sfp_port[0].i2c = { .sda = GPIO41_I2C_SDA3_MDIO1, .scl = GPIO40_I2C_SCL3_MDC1 },
+	// Right SFP port (6)
 	.sfp_port[1].pin_detect = GPIO30_ACL_BIT3_EN,
 	.sfp_port[1].pin_los = GPIO37,
 	.sfp_port[1].pin_tx_disable = GPIO_NA,
@@ -37,9 +39,6 @@ __code const struct machine machine = {
 			LEDS_1G | LEDS_LINK,
 			0 },
 		    },
-	.led_mux_custom = 1,
-	.led_mux = {0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x0f, 0x0c, 0x0d, 0x0e, 0x10, 0x11, 0x12, 0x14,
-		    0x15, 0x16, 0x18, 0x19, 0x1a, 0x1c, 0x1d, 0x1e, 0x20, 0x21, 0x22, 0x23 },
 };
 
 void machine_custom_init(void) { }


### PR DESCRIPTION
The left and right SFP ports were swapped in the machine structure. They are now correctly identified a comment is added. The custo LED-mux is removed again, as this was accidentally added for demonstration purposes. It is not necessary, as the device uses the default.