### PR TITLE
docs: mods: Fix MiB numbers.

### DIFF
--- a/doc/mods.md
+++ b/doc/mods.md
@@ -2,7 +2,7 @@
 
 ## SPI-Flash Memory
 
-SPI-Flash memory can be replaced with an other type. Because the chip is defect, like #69 & #70 or you have an unmanaged-switch with a small flash size, and want to convert it to a managed-variant to run `RTLPlayground` software on it. Currently `RTLPlayground`-firmware expects `8 MBit / 2 MiB`.
+SPI-Flash memory can be replaced with an other type. Because the chip is defect, like #69 & #70 or you have an unmanaged-switch with a small flash size, and want to convert it to a managed-variant to run `RTLPlayground` software on it. Currently `RTLPlayground`-firmware expects `8 MBit / 1 MiB`.
 
 ### Size
 
@@ -25,7 +25,7 @@ Most use package are `SO8`-type may also called `SOIC8`-type. Which can also hav
 
 ### Specification
 
-1. Size: At least `16 MBit / 4 MiB` (theoretic max. `128 MBit / 32 MiB`, but is not *tested*!)
+1. Size: At least `8 MBit / 1 MiB` (theoretic max. `128 MBit / 16 MiB`, but is not *tested*!)
 2. Speed: `62.5 MHz` or better.
 3. Support for `DUAL SPI operation`.
    Device need support for command `BBh`, `Dual I/O Fast Read` or `Fast Read Dual I/O`.


### PR DESCRIPTION
The ratio between `MBit` and `MiB` is always 8.