### PR TITLE
Check for sufficient flashsize before applying an update

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -803,47 +803,27 @@ void cmd_parser(void) __banked
 			}
 		} else if (cmd_compare(0, "stat")) {
 			port_stats_print();
-		} else if (cmd_compare(0, "flash") && cmd_words_b[1] > 0 && cmd_buffer[cmd_words_b[1]] == 'r') {
-			print_string("\nPRINT SECURITY REGISTERS\n");
+		} else if (cmd_compare(0, "flash") && cmd_words_b[1] > 0 && cmd_buffer[cmd_words_b[1]] == 's') {
+			print_string("\nSECURITY REGISTERS\n");
 			// The following will only show something else than 0xff if it was programmed for a managed switch
+			print_string("Region 1: ");
 			flash_region.addr = 0x0001000;
 			flash_region.len = 40;
 			flash_read_security();
+			print_string("\nRegion 2: ");
 			flash_region.addr = 0x0002000;
 			flash_region.len = 40;
 			flash_read_security();
+			print_string("\nRegion 3: ");
 			flash_region.addr = 0x0003000;
 			flash_region.len = 40;
 			flash_read_security();
-		} else if (cmd_compare(0, "flash") && cmd_words_b[1] > 0 && cmd_buffer[cmd_words_b[1]] == 'd') {
-			print_string("\nDUMPING FLASH\n");
-			flash_region.addr = 0;
-			flash_region.len = 255;
-			flash_dump(255);
 		} else if (cmd_compare(0, "flash") && cmd_words_b[1] > 0 && cmd_buffer[cmd_words_b[1]] == 'j') {
 			print_string("\nJEDEC ID\n");
 			flash_read_jedecid();
 		} else if (cmd_compare(0, "flash") && cmd_words_b[1] > 0 && cmd_buffer[cmd_words_b[1]] == 'u') {
-			print_string("\nUNIQUE ID\n");
+			print_string("\nUNIQUE ID (note: only 4 bytes are likely correct here!)\n");
 			flash_read_uid();
-		} else if (cmd_compare(0, "flash") && cmd_words_b[1] > 0 && cmd_buffer[cmd_words_b[1]] == 's') {
-			print_string("\nFLASH FAST MODE\n"); // Switch to flash 62.5 MHz mode
-			flash_init(1);
-			print_string("\nNow dumping flash\n");
-			flash_region.addr = 0;
-			flash_region.len = 255;
-			flash_dump(255);
-		} else if (cmd_compare(0, "flash") && cmd_words_b[1] > 0 && cmd_buffer[cmd_words_b[1]] == 'e') {
-			print_string("\nFLASH erase\n");
-			flash_region.addr = 0x20000;
-			flash_sector_erase();
-		} else if (cmd_compare(0, "flash") && cmd_words_b[1] > 0 && cmd_buffer[cmd_words_b[1]] == 'w') {
-			print_string("\nFLASH write\n");
-			for (uint8_t i = 0; i < 20; i++)
-				flash_buf[i] = greeting[i];
-			flash_region.addr = 0x200000;
-			flash_region.len = 20;
-			flash_write_bytes(flash_buf);
 		} else if (cmd_compare(0, "port") && cmd_words_b[1] > 0) {
 			parse_port();
 		} else if (cmd_compare(0, "mtu") && cmd_words_b[1] > 0) {

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -27,6 +27,7 @@ extern __code uint8_t * __code hex;
 extern __code struct f_data f_data[];
 extern __code char * __code mime_strings[];
 extern __xdata struct flash_region_t flash_region;
+extern __xdata uint32_t flash_size;
 
 // Flash buffer to optimize flash writing speed, write_len is the current filling position
 extern __xdata uint8_t flash_buf[FLASH_BUF_SIZE];
@@ -426,6 +427,12 @@ void handle_post(void)
 		p += 4; // Skip \r\n\r\n sequence at end of preamble of part
 
 		if (is_word(request_path, "upload")) {
+			if (flash_size < FIRMWARE_UPLOAD_START*2)
+			{
+				print_string("Flash too small for firmware upload!\n");
+				send_bad_request();
+				return;
+			}
 			print_string("Firmware upload started.");
 			uptr = FIRMWARE_UPLOAD_START;
 			verify_crc = 1;


### PR DESCRIPTION
- Flashsize is read via jedec-command from flash chip
  - if flashsize is not sufficient for flashing an update image:
    - the update is rejected
    - the update check at boottime is skipped (otherwise, due to address wrap-around, a device with 512k flash would copy its running image to itself and finally crash)
- cmdline "flash" commands:
  - corrected output
  - removed obsolete commands which did not do useful things other than bricking the device...
- minor cosmetics on console output