### PR TITLE
Add DW8051 MPAGE SFR

### DIFF
--- a/rtl837x_sfr.h
+++ b/rtl837x_sfr.h
@@ -40,6 +40,9 @@ __sfr __at(0x91) EXIF;
 __sfr __at(0xf8) EIP;
 __sbit __at(0xf9) PX3;
 
+/* MPAGE page (sdcc _XPAGE) register for "movx @Ri" */
+__sfr __at(0x92) _XPAGE; /* _XPAGE is used by sdcc in xstack mode */
+__sfr __at(0x92) MPAGE;
 /* SFR Bank control register: 0x0-3f. A value of 0 is bank 1 */
 __sfr __at(0x96) PSBANK;
 // SFR used to store return bank for trampoline


### PR DESCRIPTION
This adds the MPAGE (sdcc _XPAGE) SFR, which is used by sdcc in `--xstack` mode to provide the upper byte of the address for `MOVX A, @Ri` and `MOVX @Ri, A` instructions.

Classic 8051 uses the P2 SFR value for this, but the RTL IP block does not seem to be using the "Port 2 module".

From the databook:
```
To replace the function of the Port 2 latch in designs that do not use a
Port 2 module, the DW8051 provides an additional special function register,
MPAGE, at SFR address 92h. During MOVX A, @Ri and MOVX @Ri, A instructions,
the DW8051 places the contents of the MPAGE register on the upper 8 address
bits (mem_addr[15:8]). This provides the paging function that is normally
provided by the Port 2 latch. The MPAGE register has no function when a
Port 2 module is used to connect external RAM.
```