### PR TITLE
Rename bootloader to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-BOOTLOADER_ADDRESS=0x100
-
 VERSION=0.1.0
 IMAGESIZE = 524288
 DEFAULT_CONFIG_LOCATION = 454656
@@ -65,8 +63,8 @@ $(BUILDDIR)%.rel: $(BUILDDIR)%.asm
 	${ASM} ${AFLAGS} -o $@ $<
 #	mv -f $(addprefix $(basename $^), .lst .rel .sym) .
 
-$(BUILDDIR)rtlplayground.ihx: $(BUILDDIR)crtstart.rel $(OBJS) $(BUILDDIR)crc16.rel
-	$(CC) $(CC_FLAGS) -Wl-bHOME=${BOOTLOADER_ADDRESS} -Wl-bBANK1=0x14000 -Wl-bBANK2=0x24000 -Wl-r -o $@ $^
+$(BUILDDIR)rtlplayground.ihx: $(OBJS) $(BUILDDIR)crtstart.rel $(BUILDDIR)crc16.rel
+	$(CC) $(CC_FLAGS) -Wl-bHOME=0x00000 -Wl-bBANK1=0x14000 -Wl-bBANK2=0x24000 -Wl-r -o $@ $^
 
 $(BUILDDIR)rtlplayground.img: $(BUILDDIR)rtlplayground.ihx
 	objcopy --input-target=ihex -O binary $< $@

--- a/crtstart.asm
+++ b/crtstart.asm
@@ -1,44 +1,4 @@
-	.globl __start__stack
-;--------------------------------------------------------
-; Stack segment in internal ram
-;--------------------------------------------------------
-	.area	SSEG	(DATA)
-__start__stack:
-	.ds	1
-
- 	.area VECTOR    (CODE)
-	.globl __interrupt_vect
-__interrupt_vect:
- 	ljmp	__sdcc_gsinit_startup
- 	ljmp	_isr_ext0	; 0x03
-	.ds     5
-	ljmp	_isr_timer0	; 0x0b
-	.ds     5
-	ljmp	_isr_ext1	; 0x13
-	.ds     5
-	reti			; 0x1b TIMER 1 IRQ
-	.ds     7
- 	ljmp    _isr_serial	; 0x23
-	.ds     5
-	ljmp	_isr_timer2	; 0x2b TIMER 2 IRQ
-	.ds     5
-	reti			; 0x33 NOT used by DW8051
-	.ds     7
-	reti			; 0x3b Serial port 1 RX/TX IRQ
-	.ds     7
- 	ljmp    _isr_ext2	; 0x43
-	.ds     5
- 	ljmp    _isr_ext3	; 0x4b
-
-	.globl __start__stack
-
-	.area GSINIT0 (CODE)
-
-__sdcc_gsinit_startup::
-        mov     sp,#__start__stack - 1
-
 	.area GSFINAL (CODE)
-        ljmp	_bootloader
 
 __sdcc_banked_call::
 	push	_PSBANK

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1942,7 +1942,7 @@ void check_and_flash_update_image(void)
 	}
 }
 
-void bootloader(void)
+void main(void)
 {
 	ticks = 0;
 	stp_clock = STP_TICK_DIVIDER;

--- a/tools/imagebuilder.c
+++ b/tools/imagebuilder.c
@@ -106,6 +106,10 @@ int main(int argc, char **argv)
 			printf("Error reading input file.\n");
 			return 5;
 	}
+	if (buffer[0] != 2) {
+			printf("Expected LJMP at offset 0.\n");
+			return 5;
+	}
 	for (int b = BANK0_SIZE; b < BANK_STRIDE + BANK0_SIZE; b ++) {
 		if (buffer[b]) {
 			printf("WARNING: Bank 0: code segment too large at 0x%x!\n", b);


### PR DESCRIPTION
The presence of the main function is a hardcoded trigger in sdcc that causes the interrupt vectors and atomic rollback helpers to be generated as part of compilation of the file containing the main function.

This makes sure the runtime library is correctly initialized and reduces crtstart.asm to contain only the banked call helpers.

Generated code in rtlplayground.asm:
```
;--------------------------------------------------------
; interrupt vector
;--------------------------------------------------------
	.area HOME    (CODE)
__interrupt_vect:
	ljmp	__sdcc_gsinit_startup
	ljmp	_isr_ext0
	.ds	5
	ljmp	_isr_timer0
	.ds	5
	ljmp	_isr_ext1
	.ds	5
	reti
	.ds	7
	ljmp	_isr_serial
	.ds	5
	ljmp	_isr_timer2
	.ds	5
	reti
	.ds	7
	reti
	.ds	7
	ljmp	_isr_ext2
	.ds	5
	ljmp	_isr_ext3
; restartable atomic support routines
	.ds	2
sdcc_atomic_exchange_rollback_start::
	nop
	nop
sdcc_atomic_exchange_pdata_impl:
	movx	a, @r0
	mov	r3, a
	mov	a, r2
	movx	@r0, a
	sjmp	sdcc_atomic_exchange_exit
	nop
	nop
sdcc_atomic_exchange_xdata_impl:
	movx	a, @dptr
	mov	r3, a
	mov	a, r2
	movx	@dptr, a
	sjmp	sdcc_atomic_exchange_exit
sdcc_atomic_compare_exchange_idata_impl:
	mov	a, @r0
	cjne	a, ar2, .+#5
	mov	a, r3
	mov	@r0, a
	ret
	nop
sdcc_atomic_compare_exchange_pdata_impl:
	movx	a, @r0
	cjne	a, ar2, .+#5
	mov	a, r3
	movx	@r0, a
	ret
	nop
sdcc_atomic_compare_exchange_xdata_impl:
	movx	a, @dptr
	cjne	a, ar2, .+#5
	mov	a, r3
	movx	@dptr, a
	ret
sdcc_atomic_exchange_rollback_end::

sdcc_atomic_exchange_gptr_impl::
	jnb	b.6, sdcc_atomic_exchange_xdata_impl
	mov	r0, dpl
	jb	b.5, sdcc_atomic_exchange_pdata_impl
sdcc_atomic_exchange_idata_impl:
	mov	a, r2
	xch	a, @r0
	mov	dpl, a
	ret
sdcc_atomic_exchange_exit:
	mov	dpl, r3
	ret
sdcc_atomic_compare_exchange_gptr_impl::
	jnb	b.6, sdcc_atomic_compare_exchange_xdata_impl
	mov	r0, dpl
	jb	b.5, sdcc_atomic_compare_exchange_pdata_impl
	sjmp	sdcc_atomic_compare_exchange_idata_impl
```