### PR TITLE
Syslog: Duplicates console output to remote syslog server; Web-Interface: Send console commands to device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ create_build_dir:
 
 SRCS = rtlplayground.c rtl837x_flash.c rtl837x_leds.c rtl837x_phy.c rtl837x_port.c cmd_parser.c html_data.c rtl837x_igmp.c
 SRCS += rtl837x_stp.c rtl837x_pins.c dhcp.c machine.c cmd_editor.c rtl837x_bandwidth.c syslog.c
-SRCS += uip/timer.c uip/uip.c uip/uip_arp.c uip/uiplib.c uip/uip-fw.c uip/uip-neighbor.c uip/uip-split.c
+SRCS += uip/timer.c uip/uip.c uip/uip_arp.c uip/uiplib.c uip/uip-fw.c uip/uip-neighbor.c uip/uip-split.c udp_apps.c
 SRCS += httpd/httpd.c httpd/page_impl.c
 OBJS = ${SRCS:%.c=$(BUILDDIR)/%.rel}
 DEPS := ${SRCS:%.c=$(BUILDDIR)/%.d}

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ create_build_dir:
 	mkdir -p $(BUILDDIR)/httpd
 
 SRCS = rtlplayground.c rtl837x_flash.c rtl837x_leds.c rtl837x_phy.c rtl837x_port.c cmd_parser.c html_data.c rtl837x_igmp.c
-SRCS += rtl837x_stp.c rtl837x_pins.c dhcp.c machine.c cmd_editor.c rtl837x_bandwidth.c
+SRCS += rtl837x_stp.c rtl837x_pins.c dhcp.c machine.c cmd_editor.c rtl837x_bandwidth.c syslog.c
 SRCS += uip/timer.c uip/uip.c uip/uip_arp.c uip/uiplib.c uip/uip-fw.c uip/uip-neighbor.c uip/uip-split.c
 SRCS += httpd/httpd.c httpd/page_impl.c
 OBJS = ${SRCS:%.c=$(BUILDDIR)/%.rel}

--- a/cmd_editor.c
+++ b/cmd_editor.c
@@ -197,7 +197,7 @@ void cmd_edit(void) __banked
 			if (cmd_line_len)
 				cmd_available = 1;
 			else
-				print_string("\n> ");
+				print_cmd_prompt();
 			cursor = 0;
 			cmd_line_len = 0;
 			history_editptr = 0xffff;

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -41,6 +41,8 @@ extern __xdata char passwd[21];
 
 extern __xdata struct dhcp_state dhcp_state;
 
+extern __xdata uint8_t syslog_enabled;
+
 __xdata uint8_t vlan_names[VLAN_NAMES_SIZE];
 __xdata uint16_t vlan_ptr;
 extern __xdata uint16_t management_vlan;
@@ -1198,6 +1200,21 @@ void cmd_parser(void) __banked
 			parse_port();
 		} else if (cmd_compare(0, "mtu") && cmd_words_b[1] > 0) {
 			parse_mtu();
+		} else if (cmd_compare(0, "log")) {
+			print_string("Logging to UDP.\n");
+			uip_len = 100;
+			for (uint8_t i=0; i<uip_len; i++)
+				uip_buf[i+12] = i;
+			print_string("STP TX\n");
+			tcpip_output();
+		} else if (cmd_compare(0, "syslog")) {
+			if (cmd_words_b[1] > 0 && cmd_compare(1, "on")) {
+				print_string("UDP syslog enabled\n");
+				syslog_enabled = 1;
+			} else {
+				print_string("UDP syslog disabled\n");
+				syslog_enabled = 0;
+			}
 		} else if (cmd_compare(0, "ip")) {
 			if (cmd_compare(1, "dhcp")) {
 				dhcp_start();

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -1200,13 +1200,6 @@ void cmd_parser(void) __banked
 			parse_port();
 		} else if (cmd_compare(0, "mtu") && cmd_words_b[1] > 0) {
 			parse_mtu();
-		} else if (cmd_compare(0, "log")) {
-			print_string("Logging to UDP.\n");
-			uip_len = 100;
-			for (uint8_t i=0; i<uip_len; i++)
-				uip_buf[i+12] = i;
-			print_string("STP TX\n");
-			tcpip_output();
 		} else if (cmd_compare(0, "syslog")) {
 			if (cmd_words_b[1] > 0 && cmd_compare(1, "on")) {
 				syslog_start();

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -41,7 +41,6 @@ extern __xdata char passwd[21];
 
 extern __xdata struct dhcp_state dhcp_state;
 
-extern __xdata uint8_t syslog_enabled;
 extern __xdata uip_ipaddr_t syslog_addr;
 
 __xdata uint8_t vlan_names[VLAN_NAMES_SIZE];
@@ -1210,11 +1209,9 @@ void cmd_parser(void) __banked
 			tcpip_output();
 		} else if (cmd_compare(0, "syslog")) {
 			if (cmd_words_b[1] > 0 && cmd_compare(1, "on")) {
-				print_string("UDP syslog enabled\n");
-				syslog_enabled = 1;
+				syslog_start();
 			} else if (cmd_words_b[1] > 0 && cmd_compare(1, "off")){
-				print_string("UDP syslog disabled\n");
-				syslog_enabled = 0;
+				syslog_stop();
 			} else if (cmd_words_b[1] > 0 && cmd_compare(1, "ip")) {
 				if (cmd_words_b[3] < 0) {
 					print_string("Current syslog IP: ");

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -15,6 +15,7 @@
 #include "rtl837x_igmp.h"
 #include "rtl837x_bandwidth.h"
 #include "dhcp.h"
+#include "syslog.h"
 #include "uip/uip.h"
 #include "version.h"
 
@@ -40,8 +41,6 @@ extern __xdata struct flash_region_t flash_region;
 extern __xdata char passwd[21];
 
 extern __xdata struct dhcp_state dhcp_state;
-
-extern __xdata uip_ipaddr_t syslog_addr;
 
 __xdata uint8_t vlan_names[VLAN_NAMES_SIZE];
 __xdata uint16_t vlan_ptr;
@@ -1208,15 +1207,14 @@ void cmd_parser(void) __banked
 			} else if (cmd_words_b[1] > 0 && cmd_compare(1, "ip")) {
 				if (cmd_words_b[3] < 0) {
 					print_string("Current syslog IP: ");
-					itoa(syslog_addr[0]); write_char('.'); itoa(syslog_addr[0] >> 8); write_char('.');
-					itoa(syslog_addr[1]); write_char('.'); itoa(syslog_addr[1] >> 8);
+					itoa(syslog_state.server_ip[0]); write_char('.'); itoa(syslog_state.server_ip[1]); write_char('.');
+					itoa(syslog_state.server_ip[2]); write_char('.'); itoa(syslog_state.server_ip[3]);
 					return;
 				} else if (!parse_ip(cmd_words_b[2])) {
 					syslog_stop();
-					uip_ipaddr(&syslog_addr, ip[0], ip[1], ip[2], ip[3]);
-					print_string("Setting syslog IP: ");
-					itoa(ip[0]); write_char('.'); itoa(ip[1]); write_char('.');
-					itoa(ip[2]); write_char('.'); itoa(ip[3]); write_char('\n');
+					print_string("Setting new syslog IP.\n");
+					syslog_state.server_ip[0] = ip[0]; syslog_state.server_ip[1] = ip[1];
+					syslog_state.server_ip[2] = ip[2]; syslog_state.server_ip[3] = ip[3];
 					syslog_start();
 				} else {
 					print_string("Invalid IP address\n");

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -42,6 +42,7 @@ extern __xdata char passwd[21];
 extern __xdata struct dhcp_state dhcp_state;
 
 extern __xdata uint8_t syslog_enabled;
+extern __xdata uip_ipaddr_t syslog_addr;
 
 __xdata uint8_t vlan_names[VLAN_NAMES_SIZE];
 __xdata uint16_t vlan_ptr;
@@ -1211,9 +1212,23 @@ void cmd_parser(void) __banked
 			if (cmd_words_b[1] > 0 && cmd_compare(1, "on")) {
 				print_string("UDP syslog enabled\n");
 				syslog_enabled = 1;
-			} else {
+			} else if (cmd_words_b[1] > 0 && cmd_compare(1, "off")){
 				print_string("UDP syslog disabled\n");
 				syslog_enabled = 0;
+			} else if (cmd_words_b[1] > 0 && cmd_compare(1, "ip")) {
+				if (cmd_words_b[3] < 0) {
+					print_string("Current syslog IP: ");
+					itoa(syslog_addr[0]); write_char('.'); itoa(syslog_addr[0] >> 8); write_char('.');
+					itoa(syslog_addr[1]); write_char('.'); itoa(syslog_addr[1] >> 8);
+					return;
+				} else if (!parse_ip(cmd_words_b[2])) {
+					uip_ipaddr(&syslog_addr, ip[0], ip[1], ip[2], ip[3]);
+					print_string("Setting syslog IP: ");
+					itoa(ip[0]); write_char('.'); itoa(ip[1]); write_char('.');
+					itoa(ip[2]); write_char('.'); itoa(ip[3]); write_char('\n');
+				} else {
+					print_string("Invalid IP address\n");
+				}
 			}
 		} else if (cmd_compare(0, "ip")) {
 			if (cmd_compare(1, "dhcp")) {

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -1212,10 +1212,12 @@ void cmd_parser(void) __banked
 					itoa(syslog_addr[1]); write_char('.'); itoa(syslog_addr[1] >> 8);
 					return;
 				} else if (!parse_ip(cmd_words_b[2])) {
+					syslog_stop();
 					uip_ipaddr(&syslog_addr, ip[0], ip[1], ip[2], ip[3]);
 					print_string("Setting syslog IP: ");
 					itoa(ip[0]); write_char('.'); itoa(ip[1]); write_char('.');
 					itoa(ip[2]); write_char('.'); itoa(ip[3]); write_char('\n');
+					syslog_start();
 				} else {
 					print_string("Invalid IP address\n");
 				}

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -1211,13 +1211,32 @@ void cmd_parser(void) __banked
 					itoa(syslog_state.server_ip[2]); write_char('.'); itoa(syslog_state.server_ip[3]);
 					return;
 				} else if (!parse_ip(cmd_words_b[2])) {
-					syslog_stop();
+					uint8_t was_enabled = syslog_state.enabled;
+					if (was_enabled)
+						syslog_stop();
 					print_string("Setting new syslog IP.\n");
 					syslog_state.server_ip[0] = ip[0]; syslog_state.server_ip[1] = ip[1];
 					syslog_state.server_ip[2] = ip[2]; syslog_state.server_ip[3] = ip[3];
-					syslog_start();
+					if (was_enabled)
+						syslog_start();
 				} else {
 					print_string("Invalid IP address\n");
+				}
+			}
+			else if (cmd_words_b[1] < 0) {
+				print_string("Error: syslog [on|off|ip [ip-address]]\n");
+				print_string("  on/off enables or disables syslog, ip sets the syslog server IP address\n");
+			}
+			else
+			{
+				print_string("Current syslog status: ");
+				if (syslog_state.enabled) {
+					print_string("enabled, sending to ");
+					itoa(syslog_state.server_ip[0]); write_char('.'); itoa(syslog_state.server_ip[1]); write_char('.');
+					itoa(syslog_state.server_ip[2]); write_char('.'); itoa(syslog_state.server_ip[3]);
+					write_char('\n');
+				} else {
+					print_string("disabled\n");
 				}
 			}
 		} else if (cmd_compare(0, "ip")) {

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -1189,6 +1189,52 @@ err:
 	print_string("usage: bw [in|out|status] <port> [<hexvalue>|off|drop|fc]\n");
 }
 
+void parse_syslog(void)
+{
+	if (cmd_words_len < 2) // no argument -> print status
+	{
+		print_string("Current syslog status: ");
+		if (syslog_state.enabled) {
+			print_string("enabled, sending to ");
+			itoa(syslog_state.server_ip[0]); write_char('.'); itoa(syslog_state.server_ip[1]); write_char('.');
+			itoa(syslog_state.server_ip[2]); write_char('.'); itoa(syslog_state.server_ip[3]);
+			write_char('\n');
+		} else {
+			print_string("disabled\n");
+		}
+		return;
+	}
+
+	if (cmd_compare(1, "on")) {
+		syslog_start();
+	} else if (cmd_compare(1, "off")){
+		syslog_stop();
+	} else if (cmd_compare(1, "ip")) {
+		if (cmd_words_len < 3) { // no additional arguemnt -> print current ip
+			print_string("Current syslog IP: ");
+			itoa(syslog_state.server_ip[0]); write_char('.'); itoa(syslog_state.server_ip[1]); write_char('.');
+			itoa(syslog_state.server_ip[2]); write_char('.'); itoa(syslog_state.server_ip[3]);
+			return;
+		} else if (!parse_ip(cmd_words_b[2])) {
+			uint8_t was_enabled = syslog_state.enabled;
+			if (was_enabled)
+				syslog_stop();
+			print_string("Setting new syslog IP.\n");
+			syslog_state.server_ip[0] = ip[0]; syslog_state.server_ip[1] = ip[1];
+			syslog_state.server_ip[2] = ip[2]; syslog_state.server_ip[3] = ip[3];
+			if (was_enabled)
+				syslog_start();
+		} else {
+			print_string("Invalid IP address\n");
+		}
+	}
+	else
+	{
+		print_string("Error: syslog [on|off|ip [ip-address]]\n");
+		print_string("  on/off enables or disables syslog, ip sets the syslog server IP address\n");
+	}
+}
+
 // Parse command into words
 // cmd_words_len contains the number of words found.
 // cmd_words_b[] contains only start of a word offset.
@@ -1341,45 +1387,7 @@ void cmd_parser(void) __banked
 		} else if (cmd_compare(0, "mtu")) {
 			parse_mtu();
 		} else if (cmd_compare(0, "syslog")) {
-			if (cmd_words_b[1] > 0 && cmd_compare(1, "on")) {
-				syslog_start();
-			} else if (cmd_words_b[1] > 0 && cmd_compare(1, "off")){
-				syslog_stop();
-			} else if (cmd_words_b[1] > 0 && cmd_compare(1, "ip")) {
-				if (cmd_words_b[3] < 0) {
-					print_string("Current syslog IP: ");
-					itoa(syslog_state.server_ip[0]); write_char('.'); itoa(syslog_state.server_ip[1]); write_char('.');
-					itoa(syslog_state.server_ip[2]); write_char('.'); itoa(syslog_state.server_ip[3]);
-					return;
-				} else if (!parse_ip(cmd_words_b[2])) {
-					uint8_t was_enabled = syslog_state.enabled;
-					if (was_enabled)
-						syslog_stop();
-					print_string("Setting new syslog IP.\n");
-					syslog_state.server_ip[0] = ip[0]; syslog_state.server_ip[1] = ip[1];
-					syslog_state.server_ip[2] = ip[2]; syslog_state.server_ip[3] = ip[3];
-					if (was_enabled)
-						syslog_start();
-				} else {
-					print_string("Invalid IP address\n");
-				}
-			}
-			else if (cmd_words_b[1] < 0) {
-				print_string("Error: syslog [on|off|ip [ip-address]]\n");
-				print_string("  on/off enables or disables syslog, ip sets the syslog server IP address\n");
-			}
-			else
-			{
-				print_string("Current syslog status: ");
-				if (syslog_state.enabled) {
-					print_string("enabled, sending to ");
-					itoa(syslog_state.server_ip[0]); write_char('.'); itoa(syslog_state.server_ip[1]); write_char('.');
-					itoa(syslog_state.server_ip[2]); write_char('.'); itoa(syslog_state.server_ip[3]);
-					write_char('\n');
-				} else {
-					print_string("disabled\n");
-				}
-			}
+			parse_syslog();
 		} else if (cmd_compare(0, "ip")) {
 			if (cmd_compare(1, "dhcp")) {
 				dhcp_start();

--- a/dhcp.c
+++ b/dhcp.c
@@ -353,8 +353,10 @@ void dhcp_stop(void) __banked
 }
 
 
-void dhcp_callback(void) __banked
+void dhcp_callback(uint16_t lport) __banked
 {
+	if (lport != HTONS(DHCPC_CLIENT_PORT)) // Is this call for us? If not, ignore it
+		return;
 	if (!dhcp_state.state)
 		return;
 	if (uip_closed()) {

--- a/dhcp.h
+++ b/dhcp.h
@@ -16,7 +16,7 @@
 void dhcp_start(void) __banked;
 void dhcp_stop(void) __banked;
 // void dhcp_periodic(void) __banked;
-void dhcp_callback(void) __banked;
+void dhcp_callback(uint16_t lport) __banked;
 
 
 struct dhcp_state {

--- a/dhcp.h
+++ b/dhcp.h
@@ -40,9 +40,4 @@ struct dhcp_state {
 
 typedef struct dhcp_state uip_udp_appstate_t;
 
-/* Finally we define the application function to be called by uIP. */
-#ifndef UIP_UDP_APPCALL
-#define UIP_UDP_APPCALL dhcp_callback
-#endif /* UIP_APPCALL */
-
 #endif

--- a/html/system.html
+++ b/html/system.html
@@ -16,6 +16,7 @@
     <div class="tab-bar">
       <button class="tab-btn active" onclick="openTab(event, 'system-tab')">System</button>
       <button class="tab-btn" onclick="openTab(event, 'advanced-tab')">Advanced</button>
+      <button class="tab-btn" onclick="openTab(event, 'console-tab')">Console</button>
     </div>
     <nav id="sidebar"></nav>
     <div style="margin-left:16%;padding:1px 16px;height:1000px;">
@@ -54,6 +55,17 @@
       <input style="width:40%;" class="action" id="flash_startup_sub" onclick="flashStartupSave();" type="button" value="Save Startup Settings to Flash">
       <br/>
       <input style="width:40%;" class="action" id="switch_reset" onclick="resetSwitch();" type="button" value="Reset Switch">
+    </div>
+
+    <div id="console-tab" class="tab-content">
+      <h1>Console Command</h1>
+      <label for="console_command">Enter command:</label>
+      <input type="text" id="console_cmd" name="console_cmd" style="width:40%;">
+      <input style="width:20%;" class="action" id="cmd_sub" onclick="cmdSub();" type="button" value="Send Command"><br/>
+      <br/><br/> 
+      Be careful when entering console commands, you can lock yourself out!<br/>
+
+
     </div>
 
     </div>

--- a/html/system.js
+++ b/html/system.js
@@ -27,6 +27,20 @@ async function ipSub() {
   }
 }
 
+async function cmdSub() {
+  var cmd = document.getElementById('console_cmd').value;
+  try {
+    const response = await fetch('/cmd', {
+      method: 'POST',
+      body: cmd
+    });
+    console.log('Completed!', response);
+  } catch(err) {
+      console.error(`Error: ${err}`);
+  }
+}
+
+
 async function sendConfig(c) {
     const form = new FormData();
   form.append("MAX_FILE_SIZE", "4096");

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -17,6 +17,7 @@
 // #define DEBUG
 #include "debug.h"
 
+extern __xdata uip_ipaddr_t syslog_addr;
 
 #define L2_MAX_TRANSFER 30
 
@@ -227,6 +228,11 @@ void send_basic_info(void)
 	itoa_html(uip_netmask[0] >> 8); char_to_html('.');
 	itoa_html(uip_netmask[1]); char_to_html('.');
 	itoa_html(uip_netmask[1] >> 8);
+	slen += strtox(outbuf + slen, "\",\"syslog_address\":\"");
+	itoa_html(syslog_addr[0]); char_to_html('.');
+	itoa_html(syslog_addr[0] >> 8); char_to_html('.');
+	itoa_html(syslog_addr[1]); char_to_html('.');
+	itoa_html(syslog_addr[1] >> 8);
 	slen += strtox(outbuf + slen, "\",\"mac_address\":\"");
 	byte_to_html(uip_ethaddr.addr[0]); char_to_html(':');
 	byte_to_html(uip_ethaddr.addr[1]); char_to_html(':');

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -13,11 +13,10 @@
 #include "version.h"
 #include "machine.h"
 #include "page_impl.h"
+#include "syslog.h"
 
 // #define DEBUG
 #include "debug.h"
-
-extern __xdata uip_ipaddr_t syslog_addr;
 
 #define L2_MAX_TRANSFER 30
 
@@ -228,11 +227,11 @@ void send_basic_info(void)
 	itoa_html(uip_netmask[0] >> 8); char_to_html('.');
 	itoa_html(uip_netmask[1]); char_to_html('.');
 	itoa_html(uip_netmask[1] >> 8);
-	slen += strtox(outbuf + slen, "\",\"syslog_address\":\"");
-	itoa_html(syslog_addr[0]); char_to_html('.');
-	itoa_html(syslog_addr[0] >> 8); char_to_html('.');
-	itoa_html(syslog_addr[1]); char_to_html('.');
-	itoa_html(syslog_addr[1] >> 8);
+	slen += strtox(outbuf + slen, "\",\"syslog_server_ip\":\"");
+	itoa_html(syslog_state.server_ip[0]); char_to_html('.');
+	itoa_html(syslog_state.server_ip[1]); char_to_html('.');
+	itoa_html(syslog_state.server_ip[2]); char_to_html('.');
+	itoa_html(syslog_state.server_ip[3]);
 	slen += strtox(outbuf + slen, "\",\"mac_address\":\"");
 	byte_to_html(uip_ethaddr.addr[0]); char_to_html(':');
 	byte_to_html(uip_ethaddr.addr[1]); char_to_html(':');

--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -107,6 +107,7 @@ void print_byte(uint8_t a);
 void itoa(uint8_t v);
 void print_sfr_data(void);
 void print_phy_data(void);
+void print_cmd_prompt(void);
 void phy_write_mask(uint16_t phy_mask, uint8_t dev_id, uint16_t reg, uint16_t v);
 void phy_write(uint8_t phy_id, uint8_t dev_id, uint16_t reg, uint16_t v);
 void phy_read(uint8_t phy_id, uint8_t dev_id, uint16_t reg);

--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -99,6 +99,7 @@ extern __xdata uint8_t uip_buf[UIP_CONF_BUFFER_SIZE+2];
 extern __xdata struct uip_eth_addr uip_ethaddr;
 
 // Headers for calls in the common code area (HOME/BANK0)
+void print_string_no_syslog(__code char *p);
 void print_string(__code char *p);
 void print_string_x(__xdata char *p);
 void print_long(uint32_t a);
@@ -120,6 +121,7 @@ void sds_read(uint8_t sds_id, uint8_t page, uint8_t reg);
 void sds_write_v(uint8_t sds_id, uint8_t page, uint8_t reg, uint16_t v);
 void delay(uint16_t t);
 void sleep(uint16_t t);
+void write_char_no_syslog(char c);
 void write_char(char c);
 void print_reg(uint16_t reg);
 uint8_t sfp_read_reg(uint8_t slot, uint8_t reg);

--- a/rtl837x_flash.h
+++ b/rtl837x_flash.h
@@ -13,3 +13,4 @@ void flash_write_bytes(__xdata uint8_t *ptr);
 __code char* get_flash_size_str(void);
 
 #endif
+

--- a/rtl837x_pins.c
+++ b/rtl837x_pins.c
@@ -2,7 +2,10 @@
 #include "rtl837x_common.h"
 #include "rtl837x_regs.h"
 
-uint8_t i2c_bus_from_sda_pin(uint8_t sda_pin) {
+#pragma codeseg BANK2
+#pragma constseg BANK2
+
+uint8_t i2c_bus_from_sda_pin(uint8_t sda_pin) __banked {
 	switch (sda_pin) {
 		case GPIO47_I2C_SDA0:
 			return 0;
@@ -19,7 +22,7 @@ uint8_t i2c_bus_from_sda_pin(uint8_t sda_pin) {
 	}
 }
 
-uint8_t i2c_bus_from_scl_pin(uint8_t scl_pin) {
+uint8_t i2c_bus_from_scl_pin(uint8_t scl_pin) __banked{
 	switch (scl_pin) {
 		case GPIO46_I2C_SCL0:
 			return 0;
@@ -35,18 +38,18 @@ uint8_t i2c_bus_from_scl_pin(uint8_t scl_pin) {
 }
 
 /* Returns RTL837X_REG_GPIO_XX_OUTPUT register address */
-static uint16_t gpio_output_reg(uint8_t pin) {
+static uint16_t gpio_output_reg(uint8_t pin) __banked{
 	return pin < 32 ? RTL837X_REG_GPIO_00_31_OUTPUT : RTL837X_REG_GPIO_32_63_OUTPUT;
 } 
 
 /* Returns RTL837X_REG_GPIO_XX_DIRECTION register address */
-static uint16_t gpio_direction_reg(uint8_t pin) {
+static uint16_t gpio_direction_reg(uint8_t pin) __banked {
 	return pin < 32 ? RTL837X_REG_GPIO_00_31_DIRECTION : RTL837X_REG_GPIO_32_63_DIRECTION;
 } 
 
 
 /* Enable GPIO functions for pin */
-static void gpio_mux_setup(uint8_t pin)
+static void gpio_mux_setup(uint8_t pin) __banked
 {
 	// Some GPIOs require setting MUX registers to enable GPIO
 	switch (pin) {
@@ -94,7 +97,7 @@ static void gpio_mux_setup(uint8_t pin)
 	}
 }
 
-void gpio_input_setup(uint8_t pin) {
+void gpio_input_setup(uint8_t pin) __banked {
 	if (pin == GPIO_NA) { 
 		return;
 	}
@@ -103,7 +106,7 @@ void gpio_input_setup(uint8_t pin) {
 	reg_bit_clear(gpio_direction_reg(pin), (pin % 32));
 }
 
-void gpio_output_setup(uint8_t pin, __xdata uint8_t initial_val) {
+void gpio_output_setup(uint8_t pin, __xdata uint8_t initial_val) __banked{
 	if (pin == GPIO_NA) { 
 		return;
 	}

--- a/rtl837x_pins.h
+++ b/rtl837x_pins.h
@@ -72,22 +72,22 @@
 #define GPIO_NA                   0xFF
 
 /* Convert SDA PIN GPIO to I2C bus number */
-uint8_t i2c_bus_from_sda_pin(uint8_t sda_pin);
+uint8_t i2c_bus_from_sda_pin(uint8_t sda_pin) __banked;
 
 /* Convert SCL PIN GPIO to I2C bus number */
-uint8_t i2c_bus_from_scl_pin(uint8_t scl_pin);
+uint8_t i2c_bus_from_scl_pin(uint8_t scl_pin) __banked;
 
 /*
  * Setup a GPIO pin as input
  * pin: GPIO pin number 0-63
  */
-void gpio_input_setup(uint8_t pin);
+void gpio_input_setup(uint8_t pin) __banked;
 
 /*
  * Setup a GPIO pin as output
  * pin: GPIO pin number 0-63
  * initial_val: 1 for bit set in RTL837X_REG_GPIO_xx_OUTPUT, 0 for bit not set
  */
-void gpio_output_setup(uint8_t pin, __xdata uint8_t initial_val);
+void gpio_output_setup(uint8_t pin, __xdata uint8_t initial_val) __banked;
 
 #endif

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -387,7 +387,7 @@ void port_l2_setup(void) __banked
 
 void port_stats_print(void) __banked
 {
-	print_string("\n Port\tState\tLink\tTxGood\t\tTxBad\t\tRxGood\t\tRxBad\n");
+	print_string("\nPort\tState\tLink\tTxGood\t\tTxBad\t\tRxGood\t\tRxBad\n");
 	for (uint8_t i = machine.min_port; i <= machine.max_port; i++) {
 		write_char('0' + machine.log_to_phys_port[i]); write_char('\t');
 

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -23,6 +23,7 @@
 #include "uip/uip_arp.h"
 #include "machine.h"
 #include "phy.h"
+#include "syslog.h"
 
 extern __code const struct machine machine;
 extern __xdata uint32_t flash_size;
@@ -32,6 +33,12 @@ __xdata struct machine_runtime machine_detected;
 void crc16(__xdata uint8_t *v) __naked;
 void flash_default_config(void);
 void early_boot_handle_button(void);
+
+extern __xdata char logbuf[LOGBUF_SIZE];
+extern __xdata uint16_t logptr_w;
+extern __xdata uint8_t full_line_available;
+extern __xdata uint8_t syslog_enabled;
+extern __xdata char char_to_write;
 
 // See setup_serial_timer1() for valid baudrate settings!
 #define SERIAL_BAUD_RATE 115200
@@ -185,8 +192,17 @@ void write_char(char c)
 	}
 	tx_buf_empty = 0;
 	SBUF = c;
-}
 
+	char_to_write = c;
+	// syslog_write_char(); // why does this gives a linker error?
+
+	if (syslog_enabled) {
+		logbuf[logptr_w++] = c;
+		logptr_w &= (LOGBUF_SIZE - 1);
+		if (c == '\n')
+			full_line_available = 1;
+	}
+}
 
 void itoa(uint8_t v)
 {
@@ -1013,7 +1029,7 @@ void handle_rx(void)
 			if (uip_len) {
 			    tcpip_output();
 			}
-		} else if (uip_buf[ETHERTYPE_OFFSET] == 0x08 && uip_buf[ETHERTYPE_OFFSET + 1] == 0x00) { // TCP?
+		} else if (uip_buf[ETHERTYPE_OFFSET] == 0x08 && uip_buf[ETHERTYPE_OFFSET + 1] == 0x00) { // IP?
 			if (!management_vlan || management_vlan == rx_packet_vlan) {
 				uip_arp_ipin();	// Learn MAC addresses in TCP packets
 				uip_input();
@@ -1311,6 +1327,8 @@ void idle(void)
 			cmd_parser();
 		print_string("\n> ");
 	}
+
+	handle_syslog();
 }
 
 
@@ -2177,6 +2195,7 @@ void main(void)
 	uip_init();
 	uip_arp_init();
 	httpd_init();
+	syslog_init();
 
 	management_vlan = 0; // Disabled
 
@@ -2203,6 +2222,7 @@ void main(void)
 	set_sys_led_state(SYS_LED_ON);
 
 	cmd_editor_init();
+
 	while (1) {
 		cmd_edit();
 		idle(); // Enter Idle mode until interrupt occurs

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -326,7 +326,7 @@ void print_byte(uint8_t a)
 void isr_ext0(void) __interrupt(0)
 {
 	EX0 = 0;	// Disable interrupt for the moment
-	//write_char('X');
+	write_char('X');
 	IT0 = 1;	// Trigger on falling edge of external interrupt
 	EX0 = 1;	// Re-enable interrupt
 }
@@ -341,7 +341,7 @@ void isr_ext1(void) __interrupt(2)
 {
 	// This flag should only be reset after all packets have been read
 	EX1 = 0;
-	//write_char('Y');
+	write_char('Y');
 	EX1 = 1;
 }
 
@@ -352,7 +352,7 @@ void isr_ext1(void) __interrupt(2)
 void isr_ext2(void) __interrupt(8)
 {
 	EXIF &= 0xef;	// Clear IRQ flag (bit 7) in EXIF
-	//write_char('Z');
+	write_char('Z');
 	PCON |= 1; // Enter Idle mode until interrupt occurs
 }
 
@@ -363,7 +363,7 @@ void isr_ext2(void) __interrupt(8)
 void isr_ext3(void) __interrupt(9)
 {
 	EXIF &= 0xdf;	// Clear IRQ flag (bit 6) in EXIF
-	//write_char('W');
+	write_char('W');
 }
 
 // Timer2: handles system tick.

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -34,11 +34,6 @@ void crc16(__xdata uint8_t *v) __naked;
 void flash_default_config(void);
 void early_boot_handle_button(void);
 
-extern __xdata char logbuf[LOGBUF_SIZE];
-extern __xdata uint16_t logptr_w;
-extern __xdata uint8_t full_line_available;
-extern __xdata uint8_t syslog_enabled;
-
 // See setup_serial_timer1() for valid baudrate settings!
 #define SERIAL_BAUD_RATE 115200
 
@@ -179,7 +174,7 @@ void isr_serial(void) __interrupt(4)
 }
 
 
-void write_char(char c)
+void write_char_no_syslog(char c)
 {
 	do {
 	} while (tx_buf_empty == 0);
@@ -191,12 +186,17 @@ void write_char(char c)
 	}
 	tx_buf_empty = 0;
 	SBUF = c;
+}
 
-	if (syslog_enabled) {
-		logbuf[logptr_w++] = c;
-		logptr_w &= (LOGBUF_SIZE - 1);
+void write_char(char c)
+{
+	write_char_no_syslog(c);
+
+	if (syslog_state.enabled) {
+		logbuf[syslog_state.writeptr++] = c;
+		syslog_state.writeptr &= (LOGBUF_SIZE - 1);
 		if (c == '\n')
-			full_line_available = 1;
+			syslog_state.line_available = 1;
 	}
 }
 
@@ -220,6 +220,12 @@ void print_string(__code char *p)
 {
 	while (*p)
 		write_char(*p++);
+}
+
+void print_string_no_syslog(__code char *p)
+{
+	while (*p)
+		write_char_no_syslog(*p++);
 }
 
 void print_string_x(__xdata char *p)
@@ -317,6 +323,11 @@ void print_byte(uint8_t a)
 		low += 'a' - ('0' + 10);
 	}
 	write_char(low);
+}
+
+void print_cmd_prompt(void)
+{
+	print_string_no_syslog("\n> ");
 }
 
 /*

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1321,10 +1321,8 @@ void idle(void)
 		cmd_available = 0;
 		if (!cmd_tokenize())
 			cmd_parser();
-		print_string("\n> ");
+		print_cmd_prompt();
 	}
-
-	handle_syslog();
 }
 
 
@@ -2213,7 +2211,7 @@ void main(void)
 	early_boot_handle_button();
 
 	execute_config();
-	print_string("\n> ");
+	print_cmd_prompt();
 	idle_ready = 1;
 
 	set_sys_led_state(SYS_LED_ON);

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -38,7 +38,6 @@ extern __xdata char logbuf[LOGBUF_SIZE];
 extern __xdata uint16_t logptr_w;
 extern __xdata uint8_t full_line_available;
 extern __xdata uint8_t syslog_enabled;
-extern __xdata char char_to_write;
 
 // See setup_serial_timer1() for valid baudrate settings!
 #define SERIAL_BAUD_RATE 115200
@@ -193,9 +192,6 @@ void write_char(char c)
 	tx_buf_empty = 0;
 	SBUF = c;
 
-	char_to_write = c;
-	// syslog_write_char(); // why does this gives a linker error?
-
 	if (syslog_enabled) {
 		logbuf[logptr_w++] = c;
 		logptr_w &= (LOGBUF_SIZE - 1);
@@ -330,7 +326,7 @@ void print_byte(uint8_t a)
 void isr_ext0(void) __interrupt(0)
 {
 	EX0 = 0;	// Disable interrupt for the moment
-	write_char('X');
+	//write_char('X');
 	IT0 = 1;	// Trigger on falling edge of external interrupt
 	EX0 = 1;	// Re-enable interrupt
 }
@@ -345,7 +341,7 @@ void isr_ext1(void) __interrupt(2)
 {
 	// This flag should only be reset after all packets have been read
 	EX1 = 0;
-	write_char('Y');
+	//write_char('Y');
 	EX1 = 1;
 }
 
@@ -356,7 +352,7 @@ void isr_ext1(void) __interrupt(2)
 void isr_ext2(void) __interrupt(8)
 {
 	EXIF &= 0xef;	// Clear IRQ flag (bit 7) in EXIF
-	write_char('Z');
+	//write_char('Z');
 	PCON |= 1; // Enter Idle mode until interrupt occurs
 }
 
@@ -367,7 +363,7 @@ void isr_ext2(void) __interrupt(8)
 void isr_ext3(void) __interrupt(9)
 {
 	EXIF &= 0xdf;	// Clear IRQ flag (bit 6) in EXIF
-	write_char('W');
+	//write_char('W');
 }
 
 // Timer2: handles system tick.
@@ -2169,6 +2165,8 @@ void main(void)
 
 	check_and_flash_update_image();
 
+	syslog_init();
+
 #ifdef DEBUG
 	// This register seems to work on the RTL8373 only if also the SDS
 	// Is correctly configured. Therefore, we can test it, here...
@@ -2195,7 +2193,6 @@ void main(void)
 	uip_init();
 	uip_arp_init();
 	httpd_init();
-	syslog_init();
 
 	management_vlan = 0; // Disabled
 

--- a/syslog.c
+++ b/syslog.c
@@ -6,32 +6,59 @@
 #pragma codeseg BANK2
 #pragma constseg BANK2
 
-#define SYSLOG_O ((__xdata uint8_t *)&uip_buf[RTL_TAG_SIZE + VLAN_TAG_SIZE])
+#define SYSLOG_P ((__xdata uint8_t *)uip_appdata)
 
 __xdata char logbuf[LOGBUF_SIZE];
-__xdata uint16_t logptr_w = 0;
-__xdata uint16_t logptr_r = 0;
-__xdata uint8_t full_line_available = 0;
-__xdata uint8_t syslog_enabled = 0;
+__xdata uint16_t logptr_w ;
+__xdata uint16_t logptr_r;
+__xdata uint8_t full_line_available;
+__xdata uint8_t syslog_enabled;
 __xdata uip_ipaddr_t syslog_addr;
 
-#define DEST_OFFSET (0)
-#define SOURCE_OFFSET (DEST_OFFSET + 6)
-#define ETHERTYPE_OFFSET (SOURCE_OFFSET + 6)
-#define IP_HEADER_OFFSET (ETHERTYPE_OFFSET + 2)
-#define UDP_HEADER_OFFSET (IP_HEADER_OFFSET + 20)	
-#define UDP_PAYLOAD_OFFSET (UDP_HEADER_OFFSET + 8)
+struct uip_udp_conn *syslog_conn;
 
 void syslog_init(void) __banked
 {
 	syslog_enabled = 0;
+	syslog_conn = 0;
 	logptr_w = 0;
 	logptr_r = 0;
 	full_line_available = 0;
-	syslog_addr[0] = 0xffff; syslog_addr[1] = 0xffff; // Default to broadcast
+	syslog_addr[0] = 0; syslog_addr[1] = 0; // Default to 0.0.0.0
 }
 
-void handle_syslog(void) __banked
+void syslog_start(void) __banked
+{
+	if (syslog_conn == 0) {
+		syslog_conn = uip_udp_new(&syslog_addr, HTONS(514));
+		if (syslog_conn == 0) {
+			print_string("Failed to create a new UDP client\n");
+			return;
+		}
+		print_string("Started syslog to IP ");
+		itoa(syslog_addr[0]); write_char('.'); itoa(syslog_addr[0]>>8); write_char('.');
+		itoa(syslog_addr[1]); write_char('.'); itoa(syslog_addr[1]>>8); write_char('\n');
+
+		syslog_enabled = 1;
+	}
+	else {
+		print_string("Syslog is already running\n");
+	}
+}
+
+void syslog_stop(void) __banked
+{
+	syslog_enabled = 0;
+	if (syslog_conn != 0) {
+		uip_udp_remove(syslog_conn);
+		syslog_conn = 0;
+		print_string("Stopped syslog\n");
+	} else {
+		print_string("Syslog is not running\n");
+	}
+}
+
+void syslog_callback(void) __banked
 {
 	if ((logptr_r != logptr_w) && full_line_available)
 	{
@@ -39,51 +66,40 @@ void handle_syslog(void) __banked
 		if (log_size < 0)
 			log_size += LOGBUF_SIZE;
 		
-		if (log_size <= 4) {
-			// Only some newline; not worth sending to syslog, skip it
+		// Skipping linefeeds at the start of the log line
+		uint16_t log_start = logptr_r;
+		while (log_size > 0 && logbuf[log_start] == '\n') {
+			log_start = (log_start + 1) & (LOGBUF_SIZE - 1);
+			log_size--;
+		}
+
+		// Skipping linefeeds and whitespaces at the end of the log line
+		uint16_t log_end = logptr_w;
+		while ( (log_size > 0) && 
+				((logbuf[(log_end-1) & (LOGBUF_SIZE - 1)] == '\n') ||
+				 (logbuf[(log_end-1) & (LOGBUF_SIZE - 1)] == ' ')))
+		{
+			log_end = (log_end - 1) & (LOGBUF_SIZE - 1);
+			log_size--;
+		}
+
+		if (log_size == 0) {
 			logptr_r = logptr_w;
 			full_line_available = 0;
 			return;
 		}
 
-		SYSLOG_O[DEST_OFFSET]     = 255;  SYSLOG_O[DEST_OFFSET + 1] = 255; SYSLOG_O[DEST_OFFSET + 2] = 255; 
-		SYSLOG_O[DEST_OFFSET + 3] = 255;  SYSLOG_O[DEST_OFFSET + 4] = 255; SYSLOG_O[DEST_OFFSET + 5] = 255; // broadcast
-		memcpy(SYSLOG_O + SOURCE_OFFSET, uip_ethaddr.addr, 6); // Source MAC address
+		memcpyc(SYSLOG_P, "<14>", 4); // Syslog priority prefix
 
-		SYSLOG_O[ETHERTYPE_OFFSET] = 0x08; SYSLOG_O[ETHERTYPE_OFFSET + 1] = 0x00; // Ethertype: IPv4
-
-		SYSLOG_O[IP_HEADER_OFFSET     ] = 0x45; SYSLOG_O[IP_HEADER_OFFSET +  1] = 0x00; // IPv4, no options
-		SYSLOG_O[IP_HEADER_OFFSET +  2] = (20+8+4+log_size) >> 8; SYSLOG_O[IP_HEADER_OFFSET + 3] = (20+8+4+log_size) & 0xff; // Total Length (IP header + UDP header + payload)
-		SYSLOG_O[IP_HEADER_OFFSET +  4] = 0x00; SYSLOG_O[IP_HEADER_OFFSET +  5] = 0x00; // Identification
-		SYSLOG_O[IP_HEADER_OFFSET +  6] = 0x00; SYSLOG_O[IP_HEADER_OFFSET +  7] = 0x00; // Flags, Fragment Offset
-		SYSLOG_O[IP_HEADER_OFFSET +  8] = 0x40; SYSLOG_O[IP_HEADER_OFFSET +  9] = 0x11; // TTL, Protocol (UDP)
-		SYSLOG_O[IP_HEADER_OFFSET + 10] = 0x00; SYSLOG_O[IP_HEADER_OFFSET + 11] = 0x00; // Header Checksum (not calculated)
-		SYSLOG_O[IP_HEADER_OFFSET + 12] = uip_hostaddr[0] & 0xff; SYSLOG_O[IP_HEADER_OFFSET + 13] = uip_hostaddr[0] >> 8; 
-		SYSLOG_O[IP_HEADER_OFFSET + 14] = uip_hostaddr[1] & 0xff; SYSLOG_O[IP_HEADER_OFFSET + 15] = uip_hostaddr[1] >> 8;	// Source IP
-		SYSLOG_O[IP_HEADER_OFFSET + 16] = syslog_addr[0] & 0xff;  SYSLOG_O[IP_HEADER_OFFSET + 17] = syslog_addr[0] >> 8; 
-		SYSLOG_O[IP_HEADER_OFFSET + 18] = syslog_addr[1] & 0xff;  SYSLOG_O[IP_HEADER_OFFSET + 19] = syslog_addr[1] >> 8;	// Destination IP
-		
-		SYSLOG_O[UDP_HEADER_OFFSET    ] = 0x02; SYSLOG_O[UDP_HEADER_OFFSET + 1] = 0x02; // Source Port
-		SYSLOG_O[UDP_HEADER_OFFSET + 2] = 0x02; SYSLOG_O[UDP_HEADER_OFFSET + 3] = 0x02; // Destination Port
-		SYSLOG_O[UDP_HEADER_OFFSET + 4] = (8+4+log_size) >> 8; SYSLOG_O[UDP_HEADER_OFFSET + 5] = (8+4+log_size) & 0xff; // Length (UDP header + payload)
-		SYSLOG_O[UDP_HEADER_OFFSET + 6] = 0x00; SYSLOG_O[UDP_HEADER_OFFSET + 7] = 0x00; // Header Checksum (not calculated)
-
-		memcpyc(SYSLOG_O + UDP_PAYLOAD_OFFSET, "<14>", 4); // Syslog priority prefix
-
-		if (logptr_w < logptr_r) {
-			memcpy(SYSLOG_O + UDP_PAYLOAD_OFFSET + 4, logbuf + logptr_r, LOGBUF_SIZE - logptr_r);
-			memcpy(SYSLOG_O + UDP_PAYLOAD_OFFSET + 4 + LOGBUF_SIZE - logptr_r, logbuf, logptr_w);
+		if (log_end < log_start) {
+			memcpy(SYSLOG_P + 4, logbuf + log_start, LOGBUF_SIZE - log_start);
+			memcpy(SYSLOG_P + 4 + LOGBUF_SIZE - log_start, logbuf, log_end);
 		} else {
-			 memcpy(SYSLOG_O + UDP_PAYLOAD_OFFSET + 4, logbuf + logptr_r, logptr_w - logptr_r);
+			 memcpy(SYSLOG_P + 4, logbuf + log_start, log_end - log_start);
 		}
-	 	// SYSLOG_O[UDP_PAYLOAD_OFFSET + 4 + log_size - 1] = 0; // Null-terminate the payload
 
-		uip_len = UDP_PAYLOAD_OFFSET+4+log_size;
-		tcpip_output();
-
-		logptr_r += log_size;
-		logptr_r &= (LOGBUF_SIZE - 1);
-
+		uip_udp_send(log_size+4);
+		logptr_r = logptr_w;
 		full_line_available = 0;
 	}
 }

--- a/syslog.c
+++ b/syslog.c
@@ -38,7 +38,6 @@ void syslog_start(void) __banked
 		print_string("Started syslog to IP ");
 		itoa(syslog_addr[0]); write_char('.'); itoa(syslog_addr[0]>>8); write_char('.');
 		itoa(syslog_addr[1]); write_char('.'); itoa(syslog_addr[1]>>8); write_char('\n');
-
 		syslog_enabled = 1;
 	}
 	else {
@@ -58,8 +57,11 @@ void syslog_stop(void) __banked
 	}
 }
 
-void syslog_callback(void) __banked
+void syslog_callback(uint16_t lport) __banked
 {
+	if (lport != syslog_conn->lport)
+		return;
+
 	if ((logptr_r != logptr_w) && full_line_available)
 	{
 		int16_t log_size = logptr_w - logptr_r;

--- a/syslog.c
+++ b/syslog.c
@@ -14,6 +14,7 @@ __xdata uint16_t logptr_r = 0;
 __xdata uint8_t full_line_available = 0;
 __xdata uint8_t syslog_enabled = 0;
 __xdata char char_to_write = 0;
+__xdata uip_ipaddr_t syslog_addr;
 
 #define DEST_OFFSET (0)
 #define SOURCE_OFFSET (DEST_OFFSET + 6)
@@ -24,9 +25,7 @@ __xdata char char_to_write = 0;
 
 void syslog_init(void) __banked
 {
-	logptr_r = 0;
-	logptr_w = 0;
-	full_line_available = 0;
+	syslog_addr[0] = 0xffff; syslog_addr[1] = 0xffff; // Default to broadcast
 }
 
 void syslog_write_char(void) __banked
@@ -57,11 +56,7 @@ void handle_syslog(void) __banked
 		SYSLOG_O[DEST_OFFSET]     = 255;  SYSLOG_O[DEST_OFFSET + 1] = 255; SYSLOG_O[DEST_OFFSET + 2] = 255; 
 		SYSLOG_O[DEST_OFFSET + 3] = 255;  SYSLOG_O[DEST_OFFSET + 4] = 255; SYSLOG_O[DEST_OFFSET + 5] = 255; // broadcast
 		memcpy(SYSLOG_O + SOURCE_OFFSET, uip_ethaddr.addr, 6); // Source MAC address
-/*
-		SYSLOG_O[SOURCE_OFFSET]     = uip_ethaddr.addr[0]; SYSLOG_O[SOURCE_OFFSET + 1] = uip_ethaddr.addr[1]; 
-		SYSLOG_O[SOURCE_OFFSET + 2] = uip_ethaddr.addr[2]; SYSLOG_O[SOURCE_OFFSET + 3] = uip_ethaddr.addr[3];  
-		SYSLOG_O[SOURCE_OFFSET + 4] = uip_ethaddr.addr[4]; SYSLOG_O[SOURCE_OFFSET + 5] = uip_ethaddr.addr[5];
-*/		 
+
 		SYSLOG_O[ETHERTYPE_OFFSET] = 0x08; SYSLOG_O[ETHERTYPE_OFFSET + 1] = 0x00; // Ethertype: IPv4
 
 		SYSLOG_O[IP_HEADER_OFFSET     ] = 0x45; SYSLOG_O[IP_HEADER_OFFSET +  1] = 0x00; // IPv4, no options
@@ -70,10 +65,10 @@ void handle_syslog(void) __banked
 		SYSLOG_O[IP_HEADER_OFFSET +  6] = 0x00; SYSLOG_O[IP_HEADER_OFFSET +  7] = 0x00; // Flags, Fragment Offset
 		SYSLOG_O[IP_HEADER_OFFSET +  8] = 0x40; SYSLOG_O[IP_HEADER_OFFSET +  9] = 0x11; // TTL, Protocol (UDP)
 		SYSLOG_O[IP_HEADER_OFFSET + 10] = 0x00; SYSLOG_O[IP_HEADER_OFFSET + 11] = 0x00; // Header Checksum (not calculated)
-		SYSLOG_O[IP_HEADER_OFFSET + 12] = uip_hostaddr[0]&0xff; SYSLOG_O[IP_HEADER_OFFSET + 13] = uip_hostaddr[0]>>8; 
-		SYSLOG_O[IP_HEADER_OFFSET + 14] = uip_hostaddr[1]&0xff; SYSLOG_O[IP_HEADER_OFFSET + 15] = uip_hostaddr[1]>>8;	// Source IP
-		SYSLOG_O[IP_HEADER_OFFSET + 16] = 192;                  SYSLOG_O[IP_HEADER_OFFSET + 17] = 168; 
-		SYSLOG_O[IP_HEADER_OFFSET + 18] = 10;                   SYSLOG_O[IP_HEADER_OFFSET + 19] = 240;	// Destination IP	
+		SYSLOG_O[IP_HEADER_OFFSET + 12] = uip_hostaddr[0] & 0xff; SYSLOG_O[IP_HEADER_OFFSET + 13] = uip_hostaddr[0] >> 8; 
+		SYSLOG_O[IP_HEADER_OFFSET + 14] = uip_hostaddr[1] & 0xff; SYSLOG_O[IP_HEADER_OFFSET + 15] = uip_hostaddr[1] >> 8;	// Source IP
+		SYSLOG_O[IP_HEADER_OFFSET + 16] = syslog_addr[0] & 0xff;  SYSLOG_O[IP_HEADER_OFFSET + 17] = syslog_addr[0] >> 8; 
+		SYSLOG_O[IP_HEADER_OFFSET + 18] = syslog_addr[1] & 0xff;  SYSLOG_O[IP_HEADER_OFFSET + 19] = syslog_addr[1] >> 8;	// Destination IP
 		
 		SYSLOG_O[UDP_HEADER_OFFSET    ] = 0x02; SYSLOG_O[UDP_HEADER_OFFSET + 1] = 0x02; // Source Port
 		SYSLOG_O[UDP_HEADER_OFFSET + 2] = 0x02; SYSLOG_O[UDP_HEADER_OFFSET + 3] = 0x02; // Destination Port

--- a/syslog.c
+++ b/syslog.c
@@ -9,74 +9,72 @@
 #define SYSLOG_P ((__xdata uint8_t *)uip_appdata)
 
 __xdata char logbuf[LOGBUF_SIZE];
-__xdata uint16_t logptr_w ;
-__xdata uint16_t logptr_r;
-__xdata uint8_t full_line_available;
-__xdata uint8_t syslog_enabled;
-__xdata uip_ipaddr_t syslog_addr;
+__xdata struct syslog_state syslog_state;
+__xdata uip_ipaddr_t server_ip;
 
-struct uip_udp_conn *syslog_conn;
+#define state syslog_state 
 
 void syslog_init(void) __banked
 {
-	syslog_enabled = 0;
-	syslog_conn = 0;
-	logptr_w = 0;
-	logptr_r = 0;
-	full_line_available = 0;
-	syslog_addr[0] = 0; syslog_addr[1] = 0; // Default to 0.0.0.0
+	state.enabled = 0;
+	state.syslog_conn = 0;
+	state.writeptr = 0;
+	state.readptr = 0;
+	state.line_available = 0;
+	state.server_ip[0] = 0; state.server_ip[1] = 0; state.server_ip[2] = 0; state.server_ip[3] = 0;// Default to 0.0.0.0
 }
 
 void syslog_start(void) __banked
 {
-	if (syslog_conn == 0) {
-		syslog_conn = uip_udp_new(&syslog_addr, HTONS(514));
-		if (syslog_conn == 0) {
-			print_string("Failed to create a new UDP client\n");
+	if (state.syslog_conn == 0) {
+		uip_ipaddr(server_ip, state.server_ip[0], state.server_ip[1], state.server_ip[2], state.server_ip[3]);
+		state.syslog_conn = uip_udp_new(&server_ip, HTONS(514));
+		if (state.syslog_conn == 0) {
+			print_string_no_syslog("Failed to create a new UDP client\n");
 			return;
 		}
-		print_string("Started syslog to IP ");
-		itoa(syslog_addr[0]); write_char('.'); itoa(syslog_addr[0]>>8); write_char('.');
-		itoa(syslog_addr[1]); write_char('.'); itoa(syslog_addr[1]>>8); write_char('\n');
-		syslog_enabled = 1;
+		print_string_no_syslog("Started syslog to IP ");
+		itoa(state.server_ip[0]); write_char('.'); itoa(state.server_ip[1]); write_char('.');
+		itoa(state.server_ip[2]); write_char('.'); itoa(state.server_ip[3]); write_char('\n');
+		state.enabled = 1;
 	}
 	else {
-		print_string("Syslog is already running\n");
+		print_string_no_syslog("Syslog is already running\n");
 	}
 }
 
 void syslog_stop(void) __banked
 {
-	syslog_enabled = 0;
-	if (syslog_conn != 0) {
-		uip_udp_remove(syslog_conn);
-		syslog_conn = 0;
-		print_string("Stopped syslog\n");
+	state.enabled = 0;
+	if (state.syslog_conn != 0) {
+		uip_udp_remove(state.syslog_conn);
+		state.syslog_conn = 0;
+		print_string_no_syslog("Stopped syslog\n");
 	} else {
-		print_string("Syslog is not running\n");
+		print_string_no_syslog("Syslog is not running\n");
 	}
 }
 
 void syslog_callback(uint16_t lport) __banked
 {
-	if (lport != syslog_conn->lport)
+	if (lport != state.syslog_conn->lport)
 		return;
 
-	if ((logptr_r != logptr_w) && full_line_available)
+	if ((state.readptr != state.writeptr) && state.line_available)
 	{
-		int16_t log_size = logptr_w - logptr_r;
+		int16_t log_size = state.writeptr - state.readptr;
 		if (log_size < 0)
 			log_size += LOGBUF_SIZE;
 		
 		// Skipping linefeeds at the start of the log line
-		uint16_t log_start = logptr_r;
+		uint16_t log_start = state.readptr;
 		while (log_size > 0 && logbuf[log_start] == '\n') {
 			log_start = (log_start + 1) & (LOGBUF_SIZE - 1);
 			log_size--;
 		}
 
 		// Skipping linefeeds and whitespaces at the end of the log line
-		uint16_t log_end = logptr_w;
+		uint16_t log_end = state.writeptr;
 		while ( (log_size > 0) && 
 				((logbuf[(log_end-1) & (LOGBUF_SIZE - 1)] == '\n') ||
 				 (logbuf[(log_end-1) & (LOGBUF_SIZE - 1)] == ' ')))
@@ -86,8 +84,8 @@ void syslog_callback(uint16_t lport) __banked
 		}
 
 		if (log_size == 0) {
-			logptr_r = logptr_w;
-			full_line_available = 0;
+			state.readptr = state.writeptr;
+			state.line_available = 0;
 			return;
 		}
 
@@ -101,7 +99,7 @@ void syslog_callback(uint16_t lport) __banked
 		}
 
 		uip_udp_send(log_size+4);
-		logptr_r = logptr_w;
-		full_line_available = 0;
+		state.readptr = state.writeptr;
+		state.line_available = 0;
 	}
 }

--- a/syslog.c
+++ b/syslog.c
@@ -1,0 +1,101 @@
+#include "machine.h"
+#include "syslog.h"
+#include "uip/uip.h"
+#include "rtl837x_common.h"
+
+#pragma codeseg BANK2
+#pragma constseg BANK2
+
+#define SYSLOG_O ((__xdata uint8_t *)&uip_buf[RTL_TAG_SIZE + VLAN_TAG_SIZE])
+
+__xdata char logbuf[LOGBUF_SIZE];
+__xdata uint16_t logptr_w = 0;
+__xdata uint16_t logptr_r = 0;
+__xdata uint8_t full_line_available = 0;
+__xdata uint8_t syslog_enabled = 0;
+__xdata char char_to_write = 0;
+
+#define DEST_OFFSET (0)
+#define SOURCE_OFFSET (DEST_OFFSET + 6)
+#define ETHERTYPE_OFFSET (SOURCE_OFFSET + 6)
+#define IP_HEADER_OFFSET (ETHERTYPE_OFFSET + 2)
+#define UDP_HEADER_OFFSET (IP_HEADER_OFFSET + 20)	
+#define UDP_PAYLOAD_OFFSET (UDP_HEADER_OFFSET + 8)
+
+void syslog_init(void) __banked
+{
+	logptr_r = 0;
+	logptr_w = 0;
+	full_line_available = 0;
+}
+
+void syslog_write_char(void) __banked
+{
+	if (syslog_enabled) {
+		logbuf[logptr_w++] = char_to_write;
+		logptr_w &= (LOGBUF_SIZE - 1);
+		if (char_to_write == '\n')
+			full_line_available = 1;
+	}
+}
+
+void handle_syslog(void) __banked
+{
+	if ((logptr_r != logptr_w) && full_line_available)
+	{
+		int16_t log_size = logptr_w - logptr_r;
+		if (log_size < 0)
+			log_size += LOGBUF_SIZE;
+		
+		if (log_size <= 4) {
+			// Only some newline; not worth sending to syslog, skip it
+			logptr_r = logptr_w;
+			full_line_available = 0;
+			return;
+		}
+
+		SYSLOG_O[DEST_OFFSET]     = 255;  SYSLOG_O[DEST_OFFSET + 1] = 255; SYSLOG_O[DEST_OFFSET + 2] = 255; 
+		SYSLOG_O[DEST_OFFSET + 3] = 255;  SYSLOG_O[DEST_OFFSET + 4] = 255; SYSLOG_O[DEST_OFFSET + 5] = 255; // broadcast
+		memcpy(SYSLOG_O + SOURCE_OFFSET, uip_ethaddr.addr, 6); // Source MAC address
+/*
+		SYSLOG_O[SOURCE_OFFSET]     = uip_ethaddr.addr[0]; SYSLOG_O[SOURCE_OFFSET + 1] = uip_ethaddr.addr[1]; 
+		SYSLOG_O[SOURCE_OFFSET + 2] = uip_ethaddr.addr[2]; SYSLOG_O[SOURCE_OFFSET + 3] = uip_ethaddr.addr[3];  
+		SYSLOG_O[SOURCE_OFFSET + 4] = uip_ethaddr.addr[4]; SYSLOG_O[SOURCE_OFFSET + 5] = uip_ethaddr.addr[5];
+*/		 
+		SYSLOG_O[ETHERTYPE_OFFSET] = 0x08; SYSLOG_O[ETHERTYPE_OFFSET + 1] = 0x00; // Ethertype: IPv4
+
+		SYSLOG_O[IP_HEADER_OFFSET     ] = 0x45; SYSLOG_O[IP_HEADER_OFFSET +  1] = 0x00; // IPv4, no options
+		SYSLOG_O[IP_HEADER_OFFSET +  2] = (20+8+4+log_size)>>8; SYSLOG_O[IP_HEADER_OFFSET +  3] = (20+8+4+log_size)&0xff; // Total Length
+		SYSLOG_O[IP_HEADER_OFFSET +  4] = 0x00; SYSLOG_O[IP_HEADER_OFFSET +  5] = 0x00; // Identification
+		SYSLOG_O[IP_HEADER_OFFSET +  6] = 0x00; SYSLOG_O[IP_HEADER_OFFSET +  7] = 0x00; // Flags, Fragment Offset
+		SYSLOG_O[IP_HEADER_OFFSET +  8] = 0x40; SYSLOG_O[IP_HEADER_OFFSET +  9] = 0x11; // TTL, Protocol (UDP)
+		SYSLOG_O[IP_HEADER_OFFSET + 10] = 0x00; SYSLOG_O[IP_HEADER_OFFSET + 11] = 0x00; // Header Checksum (not calculated)
+		SYSLOG_O[IP_HEADER_OFFSET + 12] = uip_hostaddr[0]&0xff; SYSLOG_O[IP_HEADER_OFFSET + 13] = uip_hostaddr[0]>>8; 
+		SYSLOG_O[IP_HEADER_OFFSET + 14] = uip_hostaddr[1]&0xff; SYSLOG_O[IP_HEADER_OFFSET + 15] = uip_hostaddr[1]>>8;	// Source IP
+		SYSLOG_O[IP_HEADER_OFFSET + 16] = 192;                  SYSLOG_O[IP_HEADER_OFFSET + 17] = 168; 
+		SYSLOG_O[IP_HEADER_OFFSET + 18] = 10;                   SYSLOG_O[IP_HEADER_OFFSET + 19] = 240;	// Destination IP	
+		
+		SYSLOG_O[UDP_HEADER_OFFSET    ] = 0x02; SYSLOG_O[UDP_HEADER_OFFSET + 1] = 0x02; // Source Port
+		SYSLOG_O[UDP_HEADER_OFFSET + 2] = 0x02; SYSLOG_O[UDP_HEADER_OFFSET + 3] = 0x02; // Destination Port
+		SYSLOG_O[UDP_HEADER_OFFSET + 4] = (8+4+log_size)>>8; SYSLOG_O[UDP_HEADER_OFFSET + 5] = (8+4+log_size)&0xff; // Length
+		SYSLOG_O[UDP_HEADER_OFFSET + 6] = 0x00; SYSLOG_O[UDP_HEADER_OFFSET + 7] = 0x00; // Header Checksum (not calculated)
+
+		memcpyc(SYSLOG_O + UDP_PAYLOAD_OFFSET, "<14>", 4); // Syslog priority prefix
+
+		if (logptr_w < logptr_r) {
+			memcpy(SYSLOG_O + UDP_PAYLOAD_OFFSET + 4, logbuf + logptr_r, LOGBUF_SIZE - logptr_r);
+			memcpy(SYSLOG_O + UDP_PAYLOAD_OFFSET + 4 + LOGBUF_SIZE - logptr_r, logbuf, logptr_w);
+		} else {
+			 memcpy(SYSLOG_O + UDP_PAYLOAD_OFFSET + 4, logbuf + logptr_r, logptr_w - logptr_r);
+		}
+	 	// SYSLOG_O[UDP_PAYLOAD_OFFSET + 4 + log_size - 1] = 0; // Null-terminate the payload
+
+		uip_len = UDP_PAYLOAD_OFFSET+4+log_size;
+		tcpip_output();
+
+		logptr_r += log_size;
+		logptr_r &= (LOGBUF_SIZE - 1);
+
+		full_line_available = 0;
+	}
+}

--- a/syslog.c
+++ b/syslog.c
@@ -13,7 +13,6 @@ __xdata uint16_t logptr_w = 0;
 __xdata uint16_t logptr_r = 0;
 __xdata uint8_t full_line_available = 0;
 __xdata uint8_t syslog_enabled = 0;
-__xdata char char_to_write = 0;
 __xdata uip_ipaddr_t syslog_addr;
 
 #define DEST_OFFSET (0)
@@ -25,17 +24,11 @@ __xdata uip_ipaddr_t syslog_addr;
 
 void syslog_init(void) __banked
 {
+	syslog_enabled = 0;
+	logptr_w = 0;
+	logptr_r = 0;
+	full_line_available = 0;
 	syslog_addr[0] = 0xffff; syslog_addr[1] = 0xffff; // Default to broadcast
-}
-
-void syslog_write_char(void) __banked
-{
-	if (syslog_enabled) {
-		logbuf[logptr_w++] = char_to_write;
-		logptr_w &= (LOGBUF_SIZE - 1);
-		if (char_to_write == '\n')
-			full_line_available = 1;
-	}
 }
 
 void handle_syslog(void) __banked
@@ -60,7 +53,7 @@ void handle_syslog(void) __banked
 		SYSLOG_O[ETHERTYPE_OFFSET] = 0x08; SYSLOG_O[ETHERTYPE_OFFSET + 1] = 0x00; // Ethertype: IPv4
 
 		SYSLOG_O[IP_HEADER_OFFSET     ] = 0x45; SYSLOG_O[IP_HEADER_OFFSET +  1] = 0x00; // IPv4, no options
-		SYSLOG_O[IP_HEADER_OFFSET +  2] = (20+8+4+log_size)>>8; SYSLOG_O[IP_HEADER_OFFSET +  3] = (20+8+4+log_size)&0xff; // Total Length
+		SYSLOG_O[IP_HEADER_OFFSET +  2] = (20+8+4+log_size) >> 8; SYSLOG_O[IP_HEADER_OFFSET + 3] = (20+8+4+log_size) & 0xff; // Total Length (IP header + UDP header + payload)
 		SYSLOG_O[IP_HEADER_OFFSET +  4] = 0x00; SYSLOG_O[IP_HEADER_OFFSET +  5] = 0x00; // Identification
 		SYSLOG_O[IP_HEADER_OFFSET +  6] = 0x00; SYSLOG_O[IP_HEADER_OFFSET +  7] = 0x00; // Flags, Fragment Offset
 		SYSLOG_O[IP_HEADER_OFFSET +  8] = 0x40; SYSLOG_O[IP_HEADER_OFFSET +  9] = 0x11; // TTL, Protocol (UDP)
@@ -72,7 +65,7 @@ void handle_syslog(void) __banked
 		
 		SYSLOG_O[UDP_HEADER_OFFSET    ] = 0x02; SYSLOG_O[UDP_HEADER_OFFSET + 1] = 0x02; // Source Port
 		SYSLOG_O[UDP_HEADER_OFFSET + 2] = 0x02; SYSLOG_O[UDP_HEADER_OFFSET + 3] = 0x02; // Destination Port
-		SYSLOG_O[UDP_HEADER_OFFSET + 4] = (8+4+log_size)>>8; SYSLOG_O[UDP_HEADER_OFFSET + 5] = (8+4+log_size)&0xff; // Length
+		SYSLOG_O[UDP_HEADER_OFFSET + 4] = (8+4+log_size) >> 8; SYSLOG_O[UDP_HEADER_OFFSET + 5] = (8+4+log_size) & 0xff; // Length (UDP header + payload)
 		SYSLOG_O[UDP_HEADER_OFFSET + 6] = 0x00; SYSLOG_O[UDP_HEADER_OFFSET + 7] = 0x00; // Header Checksum (not calculated)
 
 		memcpyc(SYSLOG_O + UDP_PAYLOAD_OFFSET, "<14>", 4); // Syslog priority prefix

--- a/syslog.h
+++ b/syslog.h
@@ -5,9 +5,9 @@
 
 #define LOGBUF_SIZE 512
 
-extern __xdata char logbuf[LOGBUF_SIZE];
-
 void syslog_init(void) __banked;
-void handle_syslog(void) __banked;
+void syslog_start(void) __banked;
+void syslog_stop(void) __banked;
+void syslog_callback(void) __banked;
 
 #endif

--- a/syslog.h
+++ b/syslog.h
@@ -5,6 +5,19 @@
 
 #define LOGBUF_SIZE 512
 
+struct syslog_state {
+    uint8_t enabled;
+    uint8_t line_available;
+    uint16_t writeptr ;
+    uint16_t readptr;
+    uint8_t server_ip[4];
+
+    struct uip_udp_conn *syslog_conn;
+};
+
+extern __xdata struct syslog_state syslog_state;
+extern __xdata char logbuf[LOGBUF_SIZE];
+
 void syslog_init(void) __banked;
 void syslog_start(void) __banked;
 void syslog_stop(void) __banked;

--- a/syslog.h
+++ b/syslog.h
@@ -5,8 +5,9 @@
 
 #define LOGBUF_SIZE 512
 
+extern __xdata char logbuf[LOGBUF_SIZE];
+
 void syslog_init(void) __banked;
-void syslog_write_char(void) __banked;
 void handle_syslog(void) __banked;
 
 #endif

--- a/syslog.h
+++ b/syslog.h
@@ -8,6 +8,6 @@
 void syslog_init(void) __banked;
 void syslog_start(void) __banked;
 void syslog_stop(void) __banked;
-void syslog_callback(void) __banked;
+void syslog_callback(uint16_t lport) __banked;
 
 #endif

--- a/syslog.h
+++ b/syslog.h
@@ -1,0 +1,12 @@
+#ifndef _SYSLOG_H_
+#define _SYSLOG_H_
+
+#include <stdint.h>
+
+#define LOGBUF_SIZE 512
+
+void syslog_init(void) __banked;
+void syslog_write_char(void) __banked;
+void handle_syslog(void) __banked;
+
+#endif

--- a/udp_apps.c
+++ b/udp_apps.c
@@ -1,0 +1,17 @@
+
+#include "stdint.h"
+#include "udp_apps.h"
+
+static uint8_t callbacknr;
+
+void udp_callbacks(void)
+{
+	// Calling more than one callback from the same UIP_UDP_APPCALL does not work; we use a simple dispatcher
+	if (callbacknr == 0) {
+		dhcp_callback();
+		callbacknr = 1;
+	} else  {
+		syslog_callback();
+		callbacknr = 0;
+	}
+}

--- a/udp_apps.c
+++ b/udp_apps.c
@@ -1,17 +1,9 @@
 
-#include "stdint.h"
+#include "uip/uip.h"
 #include "udp_apps.h"
-
-static uint8_t callbacknr;
 
 void udp_callbacks(void)
 {
-	// Calling more than one callback from the same UIP_UDP_APPCALL does not work; we use a simple dispatcher
-	if (callbacknr == 0) {
-		dhcp_callback();
-		callbacknr = 1;
-	} else  {
-		syslog_callback();
-		callbacknr = 0;
-	}
+	dhcp_callback(uip_udp_conn->lport); 	// let the application decide if this is for it or not
+	syslog_callback(uip_udp_conn->lport);	// let the application decide if this is for it or not
 }

--- a/udp_apps.h
+++ b/udp_apps.h
@@ -1,0 +1,13 @@
+#ifndef _UDPAPPS_H_
+#define _UDPAPPS_H_
+
+#include "dhcp.h"
+#include "syslog.h"
+
+void udp_callbacks(void);
+
+#ifndef UIP_UDP_APPCALL
+#define UIP_UDP_APPCALL udp_callbacks
+#endif /* UIP_UDP_APPCALL */
+
+#endif

--- a/uip/uip-conf.h
+++ b/uip/uip-conf.h
@@ -153,7 +153,7 @@ typedef unsigned short uip_stats_t;
    our project. */
 /*#include "smtp.h"*/
 #include "httpd.h"
-#include "dhcp.h"
+#include "udp_apps.h"
 /*#include "telnetd.h"*/
 /*#include "webserver.h" */
 /*#include "dhcpc.h"*/

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -96,6 +96,8 @@
 
 #include "../rtl837x_common.h"
 
+extern __xdata uint8_t syslog_enabled;
+
 /*---------------------------------------------------------------------------*/
 /* Variable definitions. */
 
@@ -234,7 +236,7 @@ __xdata struct uip_stats uip_stat;
 #endif /* UIP_STATISTICS == 1 */
 
 #if UIP_LOGGING == 1
-#define UIP_LOG(m) print_string(m)
+#define UIP_LOG(m) uint8_t tmp = syslog_enabled; syslog_enabled = 0; print_string(m); syslog_enabled = tmp;
 #else
 #define UIP_LOG(m)
 #endif /* UIP_LOGGING == 1 */

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -96,8 +96,6 @@
 
 #include "../rtl837x_common.h"
 
-extern __xdata uint8_t syslog_enabled;
-
 /*---------------------------------------------------------------------------*/
 /* Variable definitions. */
 
@@ -236,7 +234,7 @@ __xdata struct uip_stats uip_stat;
 #endif /* UIP_STATISTICS == 1 */
 
 #if UIP_LOGGING == 1
-#define UIP_LOG(m) uint8_t tmp = syslog_enabled; syslog_enabled = 0; print_string(m); syslog_enabled = tmp;
+#define UIP_LOG(m) print_string_no_syslog(m);
 #else
 #define UIP_LOG(m)
 #endif /* UIP_LOGGING == 1 */


### PR DESCRIPTION
Probably far from perfect, but at least it works for me.... helps developing with devices that do not have a serial console attached.

You can enter a console command in the web interface (System Settings, Console Tab), and send it to the device.
All output from the console can be send via UDP to a configurable syslog server.
I did not try out with real syslog servers so far, but just read the messages from wireshark output....