### PR TITLE
Optimize strlen/strlen_x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CONFIG_LOCATION = 458752
 HTML_LOCATION = 262144
 
 CC = sdcc
-CC_FLAGS = -mmcs51 -I. -Ihttpd -Iuip
+CC_FLAGS = -mmcs51 -I. -Ihttpd -Iuip --peep-file peeph.def
 ASM = sdas8051
 AFLAGS= -plosgff
 

--- a/peeph.def
+++ b/peeph.def
@@ -1,0 +1,103 @@
+// optimized strlen
+replace {
+	clr	c
+	subb	a,%1
+	mov	%1,a
+	mov	a,%2
+	subb	a,%3
+	mov	%3,a
+	dec	%1
+	cjne	%1,#0xff,%4
+	dec	%3
+%4:
+} by {
+	setb	c
+	subb	a,%1
+	mov	%1,a
+	mov	a,%2
+	subb	a,%3
+	mov	%3,a
+	;	Peephole optimized decrement, merged into previous
+} if labelRefCount(%4 1)
+
+replace restart {
+%1:
+	mov	dpl,%2
+	mov	dph,%3
+	clr	a
+	movc	a,@a+dptr
+	mov	%4,a
+	inc	dptr
+	mov	%2,dpl
+	mov	%3,dph
+	mov	a,%4
+	jnz	%1
+} by {
+	mov	dpl,%2
+	mov	dph,%3
+%1:
+	clr	a
+	movc	a,@a+dptr
+	mov	%4,a
+	inc	dptr
+	jnz	%1
+	;	Peephole hoisted temporary update out of loop
+	mov	%2,dpl
+	mov	%3,dph
+	mov	a,%4
+} if labelRefCount(%1 1)
+
+replace restart {
+%1:
+	mov	dpl,%2
+	mov	dph,%3
+	movx	a,@dptr
+	mov	%4,a
+	inc	dptr
+	mov	%2,dpl
+	mov	%3,dph
+	mov	a,%4
+	jnz	%1
+} by {
+	mov	dpl,%2
+	mov	dph,%3
+%1:
+	movx	a,@dptr
+	mov	%4,a
+	inc	dptr
+	jnz	%1
+	;	Peephole hoisted temporary update out of loop
+	mov	%2,dpl
+	mov	%3,dph
+	mov	a,%4
+} if labelRefCount(%1 1)
+
+replace {
+	mov	%1, dpl
+	mov	%2, dph
+	mov	a%3,%1
+	mov	a%4,%2
+} by {
+	mov	%1, dpl
+	mov	%2, dph
+	mov	%3, dpl
+	mov	%4, dph
+	;	Peephole modified moves to enable further optimizations
+}
+
+replace {
+	mov	%1,a
+	mov	a,%2
+	subb	a,%3
+	mov	%3,a
+	mov	dpl,%1
+	mov	dph,%3
+	ret
+} by {
+	mov	dpl,a
+	;	Peephole removed redundant move before return
+	mov	a,%2
+	subb	a,%3
+	mov	dph,a
+	ret
+}

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -242,19 +242,19 @@ uint16_t strtox(register __xdata uint8_t *dst, register __code const char *s)
 
 uint16_t strlen(register __code const char *s)
 {
-	uint16_t l = 0;
-	while (s[l])
-		l++;
-	return l;
+	__code const char *x = s;
+	while (*(x++));
+	// x - s includes the nul character, adjust by -1
+	return x - s - 1;
 }
 
 
 uint16_t strlen_x(register __xdata const char *s)
 {
-	uint16_t l = 0;
-	while (s[l])
-		l++;
-	return l;
+	__xdata const char *x = s;
+	while (*(x++));
+	// x - s includes the nul character, adjust by -1
+	return x - s - 1;
 }
 
 


### PR DESCRIPTION
1. Restructuring the function for better optimization.
2. Added custom peephole rules to further clean up the generated code.

strlen before:
```
_strlen:
	mov	r6, dpl
	mov	r7, dph
;	rtlplayground.c:246: while (s[l])
	mov	r4,#0x00
	mov	r5,#0x00
00101$:
	mov	a,r4
	add	a, r6
	mov	r2,a
	mov	a,r5
	addc	a, r7
	mov	r3,a
	mov	dpl,r2
	mov	dph,r3
	clr	a
	movc	a,@a+dptr
	jz	00103$
;	rtlplayground.c:247: l++;
	inc	r4
	cjne	r4,#0x00,00101$
	inc	r5
	sjmp	00101$
00103$:
;	rtlplayground.c:248: return l;
	mov	dpl, r4
	mov	dph, r5
;	rtlplayground.c:249: }
	ret
```

strlen after:
```
_strlen:
;	rtlplayground.c:246: while (*(x++));
	mov	r6, dpl
	mov	r7, dph
00101$:
	clr	a
	movc	a,@a+dptr
	inc	dptr
	jnz	00101$
	mov	r4,dpl
	mov	r5,dph
;	rtlplayground.c:247: return x - s - 1;
	mov	a,r4
	setb	c
	subb	a,r6
;	rtlplayground.c:248: }
	mov	dpl,a
	mov	a,r5
	subb	a,r7
	mov	dph,r7
	ret
```

strlenx before:
```
_strlen_x:
	mov	r6, dpl
	mov	r7, dph
;	rtlplayground.c:255: while (s[l])
	mov	r4,#0x00
	mov	r5,#0x00
00101$:
	mov	a,r4
	add	a, r6
	mov	r2,a
	mov	a,r5
	addc	a, r7
	mov	r3,a
	mov	dpl,r2
	mov	dph,r3
	movx	a,@dptr
	jz	00103$
;	rtlplayground.c:256: l++;
	inc	r4
	cjne	r4,#0x00,00101$
	inc	r5
	sjmp	00101$
00103$:
;	rtlplayground.c:257: return l;
	mov	dpl, r4
	mov	dph, r5
;	rtlplayground.c:258: }
	ret
```

strlenx after:
```
_strlen_x:
;	rtlplayground.c:254: while (*(x++));
	mov	r6, dpl
	mov	r7, dph
00101$:
	movx	a,@dptr
	inc	dptr
	jnz	00101$
	mov	r4,dpl
	mov	r5,dph
;	rtlplayground.c:255: return x - s - 1;
	mov	a,r4
	setb	c
	subb	a,r6
;	rtlplayground.c:256: }
	mov	dpl,a
	mov	a,r5
	subb	a,r7
	mov	dph,r7
	ret
```