### PR TITLE
Web request concurrency management

### DIFF
--- a/html/bandwidth.js
+++ b/html/bandwidth.js
@@ -3,7 +3,6 @@ function createBW() {
   var tbl = document.getElementById('bwtable');
   const limit = '<input type="checkbox" id="limit_port" onchange="exec();">'
   if (tbl.rows.length <= 2  && numPorts) {
-     clearInterval(createBWInterval);
      console.log("CREATING TABLE ", tbl.rows.length);
      for (let i = 2; i < 2 + numPorts; i++) {
        const tr = tbl.insertRow();
@@ -94,6 +93,7 @@ async function applyBandwidth(i) {
 function getBW() {
   var xhttp = new XMLHttpRequest();
   xhttp.onreadystatechange = function() {
+    console.log("IN getBW ");
     if (this.readyState == 4 && this.status == 200) {
       const s = JSON.parse(xhttp.responseText);
       console.log("BW: ", JSON.stringify(s));
@@ -126,11 +126,13 @@ function getBW() {
     }
   };
   xhttp.open("GET", "/bandwidth.json", true);
-  xhttp.timeout = 1500; xhttp.send();
+  xhttp.timeout = 1500; sendXHTTP(xhttp);
 }
 
 window.addEventListener("load", function() {
-  getBW();
-  const iCount = setInterval(getBW, 2000);
+  update( () => {
+    createBW();
+    getBW();
+    const interval = setInterval(update, 2000);
+  });
 });
-const createBWInterval = setInterval(createBW, 1010);

--- a/html/eee.js
+++ b/html/eee.js
@@ -1,7 +1,6 @@
 function createEEE() {
   var tbl = document.getElementById('eeetable');
    if (tbl.rows.length <= 2  && numPorts) {
-     clearInterval(createEEEInterval);
      console.log("CREATING TABLE ", tbl.rows.length);
      for (let i = 2; i < 2 + numPorts; i++) {
       console.log("Table row: " + i + "pState: " + pState[i-2]);
@@ -40,11 +39,14 @@ function getEEE() {
     }
   };
   xhttp.open("GET", "/eee.json", true);
-  xhttp.timeout = 1500; xhttp.send();
+  xhttp.timeout = 1500; sendXHTTP(xhttp);
 }
 
 window.addEventListener("load", function() {
-  getEEE();
-  const iCount = setInterval(getEEE, 2000);
+  update( () => {
+    createEEE();
+    getEEE();
+    const interval = setInterval(update, 2000);
+    const iCount = setInterval(getEEE, 2000);
+  });
 });
-const createEEEInterval = setInterval(createEEE, 1000);

--- a/html/index.html
+++ b/html/index.html
@@ -2,6 +2,13 @@
 <html>
   <script src="/main.js"></script>
   <script src="/main_info.js"></script>
+  <script>
+  window.addEventListener("load", function() {
+    update( () => {
+      const interval = setInterval(update, 2000);
+    });
+  });
+  </script>
   <link rel="stylesheet" href="style.css">
   <title>FreeSwitchOS Main Page</title>
 </head>

--- a/html/l2.js
+++ b/html/l2.js
@@ -130,10 +130,14 @@ function getL2() {
     }
   };
   xhttp.open("GET", "/l2.json?idx=" + l2CurrentEntry, true);
-  xhttp.timeout = 1500; xhttp.send();
+  xhttp.timeout = 1500; sendXHTTP(xhttp);
 }
 
 window.addEventListener("load", function() {
-  l2GetInterval = setInterval(getL2, 1000);
+  update( () => {
+    getL2();
+    const interval = setInterval(update, 2000);
+    l2GetInterval = setInterval(getL2, 1000);
+  });;
 });
 

--- a/html/lag.js
+++ b/html/lag.js
@@ -3,7 +3,6 @@ var lagInterval = Number();
 function lagForm() {
   if (!numPorts)
     return;
-  clearInterval(lagInterval);
   for (let j=0; j < 4; j++) {
     var lag = "mLAG" + j
     console.log("Adding LAG " + lag)
@@ -35,9 +34,6 @@ function setL(p, c){
   console.log("LAG setting: ", p, " to ", c);
   document.getElementById(p).checked=c;
 }
-window.addEventListener("load", function() {
-  lagInterval = setInterval(lagForm, 200);
-});
 
 function fetchLag() {
   var xhttp = new XMLHttpRequest();
@@ -58,7 +54,7 @@ function fetchLag() {
     }
   };
   xhttp.open("GET", `/lag.json`, true);
-  xhttp.send();
+  sendXHTTP(xhttp);
 }
 async function lagSub(l) {
   var cmd = "lag " + l;
@@ -76,3 +72,10 @@ async function lagSub(l) {
     console.error(`Error: ${err}`);
   }
 }
+
+window.addEventListener("load", function() {
+  update( () => {
+    lagForm();
+    const interval = setInterval(update, 2000);
+  });
+});

--- a/html/main.js
+++ b/html/main.js
@@ -9,6 +9,8 @@ var pAdvertised = new Int8Array(10);
 var numPorts = 0;
 var logToPhysPort = new Int8Array(10);
 var physToLogPort = new Int8Array(10);
+var currentRequests = [];
+var currentCallback;
 function drawPorts() {
   var f = document.getElementById('ports');
   console.log("DRAWING PORTS: ", numPorts);
@@ -38,9 +40,10 @@ function drawPorts() {
   }
 }
 
-function update() {
+function update(callback) {
   var xhttp = new XMLHttpRequest();
   xhttp.onreadystatechange = function() {
+    console.log("IN UPDATE ");
     if (this.readyState == 4 && this.status == 401)
 	    document.location = "/login.html"
     if (this.readyState == 4 && this.status == 200) {
@@ -105,13 +108,40 @@ function update() {
 	  tt.innerHTML = iHTML;
 	}
       }
+      if (callback)
+	callback();
     }
   };
   xhttp.open("GET", "/status.json", true);
-  xhttp.timeout = 5000; xhttp.send();
+  xhttp.timeout = 5000;
+  sendXHTTP(xhttp);
 }
 
-window.addEventListener("load", function() {
-  update();
-  const interval = setInterval(update, 2000);
-});
+function callbackXHTTP()
+{
+  x = currentRequests.shift();
+  x.onreadystatechange = currentCallback;
+  x.onreadystatechange();
+  if (currentRequests.length === 0)
+    return;
+  x = currentRequests[0];
+  currentCallback = x.onreadystatechange;
+  x.onreadystatechange = callbackXHTTP;
+  setTimeout(() => {
+	  x.send();
+  }, 20);
+}
+
+function sendXHTTP(x)
+{
+  console.log("sendXHTTP ", x);
+  if (currentRequests.length === 0) {
+    currentRequests.push(x);
+    currentCallback = x.onreadystatechange;
+    x.onreadystatechange = callbackXHTTP;
+    x.send();
+    return;
+  }
+  currentRequests.push(x);
+}
+

--- a/html/mirror.js
+++ b/html/mirror.js
@@ -4,7 +4,6 @@ const mirrors = ["mPortsTX", "mPortsRX"];
 function mirrorForm() {
   if (!numPorts)
     return;
-  clearInterval(mirrorInterval);
   for (let j=0; j < mirrors.length; j++) {
     console.log("Adding Mirror " + j)
     var m = document.getElementById(mirrors[j]);
@@ -34,9 +33,6 @@ function mirrorForm() {
 function setM(p, c){
   document.getElementById(p).checked=c;
 }
-window.addEventListener("load", function() {
-  mirrorInterval = setInterval(mirrorForm, 200);
-});
 
 function fetchMirror() {
   var xhttp = new XMLHttpRequest();
@@ -51,11 +47,18 @@ function fetchMirror() {
       for (let i = 1; i <= numPorts; i++) {
         let p = i - 1;
         if (numPorts < 9)
-          p = physToLogPort[p];members & (1<<p)
+          p = physToLogPort[p];
         setM("mPortsTX"+i, m_tx&(1<<p)); setM("mPortsRX"+i, m_rx&(1<<p));
       }
     }
   };
   xhttp.open("GET", `/mirror.json`, true);
-  xhttp.send();
+  sendXHTTP(xhttp);
 }
+
+window.addEventListener("load", function() {
+  update( () => {
+    mirrorForm();
+    const interval = setInterval(update, 2000);
+  });
+});

--- a/html/ports.js
+++ b/html/ports.js
@@ -3,7 +3,6 @@ var clicked = new Int8Array(10);
 function createPortTable() {
   var tbl = document.getElementById('speedtable');
    if (tbl.rows.length <= 2 && numPorts) {
-     clearInterval(pTableInterval);
      const sSelect = '<select name="speed_sel" id="speed_sel">'
       + '<option value="auto">Auto</option>'
       + '<option value="2g5">2500MBit/Full</option>'
@@ -130,17 +129,19 @@ function getMTUs() {
         if (!mtu)
           continue;
         mtu.value = mtus[n];
-        clearInterval(pMTUInterval);
       }
     }
   };
   xhttp.open("GET", "/mtu.json", true);
-  xhttp.timeout = 1500; xhttp.send();
+  xhttp.timeout = 1500; sendXHTTP(xhttp);
 }
 
 window.addEventListener("load", function() {
-  const updatePortTableInterval = setInterval(updatePortTable, 1000);
+  update( () => {
+    createPortTable();
+    updatePortTable();
+    getMTUs()
+    const interval = setInterval(update, 2000);
+    const updatePortTableInterval = setInterval(updatePortTable, 1000);
+  });
 });
-
-const pTableInterval = setInterval(createPortTable, 1000);
-const pMTUInterval = setInterval(getMTUs, 1200);

--- a/html/stat.js
+++ b/html/stat.js
@@ -151,7 +151,7 @@ function getCounters(port) {
     }
   };
   xhttp.open("GET", "/counters.json?port=" + port, true);
-  xhttp.timeout = 1500; xhttp.send();
+  xhttp.timeout = 1500; sendXHTTP(xhttp);
 }
 
 
@@ -184,8 +184,6 @@ function fillStats() {
   }
 }
 
-const stat = setInterval(fillStats, 1000);
-
 const popup = document.getElementById('popup');
 const closePopup = document.getElementById('closePopup');
 closePopup.addEventListener('click', () => {
@@ -195,4 +193,13 @@ window.addEventListener('click', (event) => {
   if (event.target === popup) {
     popup.style.display = 'none';
   }
+});
+
+window.addEventListener("load", function() {
+  update( () => {
+    update();
+    fillStats();
+    const stat = setInterval(fillStats, 1000);
+    const interval = setInterval(update, 2000);
+  });
 });

--- a/html/vlan.js
+++ b/html/vlan.js
@@ -3,7 +3,6 @@ var vlanInterval = Number();
 function vlanForm() {
   if (!numPorts)
     return;
-  clearInterval(vlanInterval);
   var t = document.getElementById('tPorts');
   var u = document.getElementById('uPorts');
   var p = document.getElementById('pPorts');
@@ -58,10 +57,6 @@ function pvClicked(p){
   }
 }
 
-window.addEventListener("load", function() {
-  vlanInterval = setInterval(vlanForm, 100);
-});
-
 function fetchVLAN() {
   var xhttp = new XMLHttpRequest();
   xhttp.onreadystatechange = function() {
@@ -83,5 +78,12 @@ function fetchVLAN() {
     return;
   }
   xhttp.open("GET", `/vlan.json?vid=${v}`, true);
-  xhttp.send(); 
+  sendXHTTP(xhttp);
 }
+
+window.addEventListener("load", function() {
+  update( () => {
+    vlanForm();
+    const interval = setInterval(update, 2000);
+  });
+});


### PR DESCRIPTION
The web-server in RTLPlayground is single-treaded and can only handle 1 concurrent connection. Web-Browsers such as Firefox use up to 6 concurrent connections to a given domain. This will lead to the `tcp: found no unused connections` showing up in the CLI and timeouts happening in the connections from the browser. While it does not seem possible to control this concurrency for connections for .html and .js files, it is possible to control this behaviour for the xhttp requests done to transfer the status of the ports and the information on the web-pages of the device.

Implement a queueing system for the xhttp requests and control the sequence of .json calls when a page is created.

<img width="2733" height="588" alt="Screenshot_20260306_185542" src="https://github.com/user-attachments/assets/68a7b3ca-56d2-41ae-9d5d-4716f842504b" />

As can be seen, the calls for `status.json` and `bandwidth.json` are now coordinated making them finish in < 40ms. The coordination of the sequence of .json requests at the load of a page makes it possible to reload a page in < 300ms, which appears as if the page loads instantaneously.

Of course, the better solution would be to add further concurrent connections to uIP, making use of a queueing system and possibly the use of interrupt-driven RX, however, in terms of snappiness, the present solution already goes a long way.

This is currently on top of the bandwidth PR, but will become independent once those are merged. This is mostly to start testing and discussion.