### PR TITLE
Console: Handle ^H as backspace

### DIFF
--- a/cmd_editor.c
+++ b/cmd_editor.c
@@ -169,7 +169,7 @@ void cmd_edit(void) __banked
 			} else { // An unknown or not yet complete Escape sequence: wait
 				continue;
 			}
-		} else if (sbuf[l] == 127) {  // Backspace
+		} else if (sbuf[l] == 127 || sbuf[l] == 8) {  // Backspace DEL or BS/^H
 			if (cursor > 0) {
 				write_char('\010');
 				for (uint8_t i = cursor; i < cmd_line_len; i++)


### PR DESCRIPTION
Currently only ASCII DEL (key code 127) is handled as backspace, but some terminal emulators are sending ^H which is ASCII BS (key code 8). Looks like we can safely treat both in the same matter.

Tested on minicom switching backspace to both keycodes seems to be working fine. 