### PR TITLE
Cleanup Frame header structures and fix management VLAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ create_build_dir:
 	mkdir -p $(BUILDDIR)/httpd
 
 SRCS = rtlplayground.c rtl837x_flash.c rtl837x_leds.c rtl837x_phy.c rtl837x_port.c cmd_parser.c html_data.c rtl837x_igmp.c
-SRCS += rtl837x_stp.c rtl837x_pins.c dhcp.c machine.c cmd_editor.c rtl837x_bandwidth.c
+SRCS += rtl837x_stp.c rtl837x_pins.c dhcp.c machine.c cmd_editor.c rtl837x_bandwidth.c rtl837x_init.c
 SRCS += uip/timer.c uip/uip.c uip/uip_arp.c uip/uiplib.c uip/uip-fw.c uip/uip-neighbor.c uip/uip-split.c
 SRCS += httpd/httpd.c httpd/page_impl.c
 OBJS = ${SRCS:%.c=$(BUILDDIR)/%.rel}

--- a/dhcp.c
+++ b/dhcp.c
@@ -71,11 +71,6 @@ struct dhcp_pkt {
 	uint8_t cookie[4];
 };
 
-/*
-#define DHCP_P ((__xdata struct dhcp_pkt *)&uip_buf[RTL_TAG_SIZE + VLAN_TAG_SIZE])
-#define DHCP_OPT ((__xdata uint8_t *)&uip_buf[RTL_TAG_SIZE + VLAN_TAG_SIZE + sizeof (struct dhcp_pkt)])
-*/
-
 #define DHCP_P ((__xdata struct dhcp_pkt *)uip_appdata)
 #define DHCP_OPT ((__xdata uint8_t *)(uip_appdata) + sizeof (struct dhcp_pkt))
 

--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -72,18 +72,9 @@ struct vlan_tag {
 #define RTL_FRAME_TAG_ID	0x8899
 #define RTL_FRAME_TAG_VERSION	0x04
 
-struct rtl_frame_desc {
-	uint8_t padding[VLAN_TAG_SIZE]; // Pad to the size of a RTL-VLAN tag or dot1q-tag
-	uint8_t tx_seq;
-	uint8_t chksum_flags;	// 0x7 enables Checksums for frame header, L2 and L3
-	uint8_t reserved_1 [2];
-	uint16_t len; // Length is Little Endian
-	uint8_t reserved_2 [2];
-};
-
 // For TX, an 8 byte (plus 4 byte padding when when VLAN is enabled)
 // header describing the frame to be moved to the Asic is used
-#define RTL_FRAME_DESC_SIZE	(sizeof (struct rtl_frame_desc))
+#define RTL_FRAME_DESC_SIZE	12
 
 // This is the standard size of an Ethernet frame header
 #define ETHER_HEADER_SIZE	14

--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -70,10 +70,20 @@ struct vlan_tag {
 #define RTL_TAG_SIZE		(sizeof (struct rtl_tag))
 #define VLAN_TAG_SIZE		(sizeof (struct vlan_tag))
 #define RTL_FRAME_TAG_ID	0x8899
+#define RTL_FRAME_TAG_VERSION	0x04
 
-// For RX and TX, an 8 byte header describing the frame to be moved to the Asic
-// and received from the Asic is used
-#define RTL_FRAME_HEADER_SIZE	8
+struct rtl_frame_desc {
+	uint8_t padding[VLAN_TAG_SIZE]; // Pad to the size of a RTL-VLAN tag or dot1q-tag
+	uint8_t tx_seq;
+	uint8_t chksum_flags;	// 0x7 enables Checksums for frame header, L2 and L3
+	uint8_t reserved_1 [2];
+	uint16_t len; // Length is Little Endian
+	uint8_t reserved_2 [2];
+};
+
+// For TX, an 8 byte (plus 4 byte padding when when VLAN is enabled)
+// header describing the frame to be moved to the Asic is used
+#define RTL_FRAME_DESC_SIZE	(sizeof (struct rtl_frame_desc))
 
 // This is the standard size of an Ethernet frame header
 #define ETHER_HEADER_SIZE	14
@@ -152,5 +162,8 @@ void read_reg_timer(__xdata uint32_t * tmr);
 void sfp_print_info(uint8_t sfp);
 bool gpio_pin_test(uint8_t pin);
 void set_sys_led_state(uint8_t state);
-
+void sds_read(uint8_t sds_id, uint8_t page, uint8_t reg);
+void sds_write_v(uint8_t sds_id, uint8_t page, uint8_t reg, uint16_t v);
+void sds_config_mac(uint8_t sds, uint8_t mode);
+void sds_config(uint8_t sds, uint8_t mode);
 #endif

--- a/rtl837x_init.c
+++ b/rtl837x_init.c
@@ -1,0 +1,247 @@
+#include <stdint.h>
+#include "rtl837x_common.h"
+#include "rtl837x_sfr.h"
+#include "rtl837x_regs.h"
+#include "rtl837x_port.h"
+#include "rtl837x_phy.h"
+#include "phy.h"
+#include "machine.h"
+
+extern __xdata uint8_t sfr_data[4];
+extern __code struct machine machine;
+extern __xdata struct machine_runtime machine_detected;
+
+#pragma codeseg BANK2
+#pragma constseg BANK2
+
+/*
+ * Configure the PHY-Side of the SDS-SDS link between SoC and PHY
+ */
+void static sds_init(void)
+{
+/*
+	p001e.000d:9535 R02f8-00009535 R02f4-0000953a P000001.1e00000d:953a
+	p001e.000d:953a p001e.000d:953a R02f8-0000953a R02f4-00009530 P000001.1e00000d:9530
+
+	RTL8373:
+	p001e.000d:0010 R02f8-00000010 R02f4-0000001a P000001.1e00000d:b7fe
+	p001e.000d:0010 p001e.000d:0010	R02f8-00000010 R02f4-00000010 P000001.1e00000d:b7fe
+*/
+	phy_read(0, PHY_MMD30, 0xd);
+	uint16_t pval = SFR_DATA_U16;
+
+	// PHY Initialization:
+	REG_WRITE(0x2f8, 0, 0, pval >> 8, pval);
+	delay(20);
+
+	pval &= 0xfff0;
+	pval |= 0x0a;
+	REG_WRITE(0x2f4, 0, 0, pval >> 8, pval);
+	delay(10);
+
+	phy_write_mask(0x1, PHY_MMD30, 0xd, pval);
+
+	phy_read(0, PHY_MMD30, 0xd);
+	pval = SFR_DATA_U16;
+
+	REG_WRITE(0x2f8, 0, 0, pval >> 8, pval);
+
+	pval &= 0xfff0;
+	REG_WRITE(0x2f4, 0, 0, pval >> 8, pval);
+
+	phy_write_mask(0x1, PHY_MMD30, 0xd, pval);
+
+	if (machine_detected.isN) {
+		uint16_t pval;
+
+		print_string("  N-settings");
+		// Serdes 0 RX PN swap for 64B/66B
+		sds_read(1, 6, 2);
+		pval = SFR_DATA_U16;
+		sds_write_v(1, 6, 2, pval | 0x2000);
+
+		// Serdes 1 RX PN swap for 8B/10B
+		sds_read(1, 0, 0);
+		pval = SFR_DATA_U16;
+		sds_write_v(1, 0, 0, pval | 0x200);
+
+		// Serdes 0 RX PN swap for 64B/66B
+		sds_read(0, 6, 2);
+		pval = SFR_DATA_U16;
+		sds_write_v(0, 6, 2, pval | 0x2000);
+
+		if (machine_detected.isRTL8373) {
+			// RTL8224: Serdes 0 RX PN swap for 64B/66B
+			// We assume that RTL8373N always paired with RTL8224N.
+			// This sds register value is 0x0000 at reset.
+			// So only write to it.
+			RTL8224_SDS_WRITE(0, 6, 2, 0x2000);
+		} else {
+			// Serdes 0 RX PN swap for 8B/10B
+			sds_read(0, 0, 0);
+			pval = SFR_DATA_U16;
+			sds_write_v(0, 0, 0, pval | 0x200);
+		}
+	}
+}
+
+
+void rtl8373_init(void) __banked
+{
+	print_string("\nrtl8373_init called\n");
+
+	// r65d8:3ffbedff R65d8-3ffbedff
+	reg_bit_set(0x65d8, 0x1d);
+
+	sds_init();
+	// Disable all SERDES for configuration
+	REG_SET(RTL837X_REG_SDS_MODES, 0x000037ff);
+
+	// q000601:c800 Q000601:c804 q000601:c804 Q000601:c800
+	sds_read(0, 0x06, 0x01);
+	uint16_t pval = SFR_DATA_U16;
+	sds_write_v(0, 0x06, 0x01, pval | 0x04);
+	delay(50);
+	sds_read(0, 0x06, 0x01);
+	pval = SFR_DATA_U16;
+	sds_write_v(0, 0x06, 0x01, pval & 0xfffb);
+
+	phy_config_8224();
+	sds_config_mac(1, SDS_OFF);    // Off for now until SFP+ port used
+	sds_config_mac(2, SDS_SGMII);  // For RTL8224
+	sds_config(0, SDS_QXGMII);
+
+	// SDS 1 setup
+	// q012100:4902 Q012100:4906 q013605:0000 Q013605:4000 Q011f02:001f q011f15:0086
+	sds_write_v(1, 0x21, 0x00, 0x4906);
+	sds_write_v(1, 0x36, 0x05, 0x4000);
+	sds_write_v(1, 0x1f, 0x02, 0x001f);
+	sds_read(1, 0x1f, 0x15);
+	pval = SFR_DATA_U16;
+
+	// r0a90:000000f3 R0a90-000000fc
+	reg_read_m(RTL837X_CFG_PHY_MDI_REVERSE);
+	sfr_mask_data(0, 0x0f,0x0c);
+	reg_write_m(RTL837X_CFG_PHY_MDI_REVERSE);
+
+	if (machine_detected.isN) {
+		print_string("  TX_POLARITY_SWAP\n");
+		// FOR N-Version: #TX_POLARITY_SWAP
+		reg_read_m(RTL837X_CFG_PHY_TX_POLARITY_SWAP);
+			sfr_data[2] = 0x59;
+			sfr_data[3] = 0x6a;
+		reg_write_m(RTL837X_CFG_PHY_TX_POLARITY_SWAP);
+	}
+
+	rtl8224_phy_enable();
+
+	// Disable PHYs for configuration
+	phy_write_mask(0xff,PHY_MMD31,0xa610,0x2858);
+
+	// Set bits 0x13 and 0x14 of 0x5fd4
+	// r5fd4:0002914a R5fd4-001a914a
+	reg_bit_set(0x5fd4, 0x13);
+	reg_bit_set(0x5fd4, 0x14);
+
+	// Configure ports
+	uint16_t reg = 0x1238; // Port base register for the bits we set
+	for (char i = 0; i < 9; i++) {
+		// Bit 7 (0x40) enables replacement of the RTL-VLAN tag with an 802.1Q VLAN tag
+		REG_SET(reg, 0xe77);
+		reg += 0x100;
+	}
+
+	// r0b7c:000000d8 R0b7c-000000f8 r6040:00000030 R6040-00000031
+	reg_bit_set(0xb7c, 5);
+
+	// R7124-00001050 R7128-00001050 R712c-00001050 R7130-00001050 R7134-00001050 R7138-00001050
+	// R713c-00001050 R7140-00001050 R7144-00001050 R7148-00001050
+	REG_SET(0x7124, 0x1050); REG_SET(0x7128, 0x1050); REG_SET(0x712c, 0x1050);
+	REG_SET(0x7130, 0x1050); REG_SET(0x7134, 0x1050); REG_SET(0x7138, 0x1050);
+	REG_SET(0x713c, 0x1050); REG_SET(0x7140, 0x1050); REG_SET(0x7144, 0x1050);
+	REG_SET(0x7148, 0x1050);
+
+	reg_bit_set(RTL837X_REG_HW_CONF, 0);
+
+	// enable EEE for all ports at 2.5G and 10G, but don't reset the PHYs
+	port_eee_enable_all(EEE_2G5 | EEE_NORESET);
+
+	// TODO: patch the PHYs
+
+	// Re-enable PHY after configuration
+	phy_write_mask(0xff,PHY_MMD31,0xa610,0x2058);
+
+	// Enables MAC access
+	// Set bits 0xc-0x14 of 0x632c to 0x1f8, see rtl8372_init
+	// r632c:00000540 R632c-001f8540 // RTL8373: 001ff540
+	reg_read_m(0x632c);
+	sfr_mask_data(1, 0x70, 0xf0); // The ports of the RTL8824
+	sfr_mask_data(2, 0x10, 0x1f);
+	reg_write_m(0x632c);
+
+	print_string("\nrtl8373_init done\n");
+}
+
+
+void rtl8372_init(void) __banked
+{
+	print_string("\nrtl8372_init called\n");
+
+	sds_init();
+	phy_config(8);	// PHY configuration: External 8221B?
+	phy_config(3);	// PHY configuration: all internal PHYs?
+	// Set the MAC SerDes Modes Bits 0-4: SDS 0 = 0x2 (0x2), Bits 5-9: SDS 1: 1f (off)
+	// r7b20:00000bff R7b20-00000bff r7b20:00000bff R7b20-00000bff r7b20:00000bff R7b20-000003ff r7b20:000003ff R7b20-000003e2 r7b20:000003e2 R7b20-000003e2
+	reg_read_m(RTL837X_REG_SDS_MODES);
+	sfr_mask_data(1, 0, 0x03);
+	sfr_mask_data(0, 0, 0xe2);
+	reg_write_m(RTL837X_REG_SDS_MODES);
+
+	// r0a90:000000f3 R0a90-000000fc
+	reg_read_m(RTL837X_CFG_PHY_MDI_REVERSE);
+	sfr_mask_data(0, 0x0f, 0x0c);
+	reg_write_m(RTL837X_CFG_PHY_MDI_REVERSE);
+
+	// Disable PHYs for configuration
+	phy_write_mask(0xf0,PHY_MMD31,0xa610,0x2858);
+
+	// Set bits 0x13 and 0x14 of 0x5fd4
+	// r5fd4:0002914a R5fd4-001a914a
+	reg_bit_set(0x5fd4, 0x13);
+	reg_bit_set(0x5fd4, 0x14);
+
+	// Configure ports 3-8:
+	//
+	// r1538:00000e33 R1538-00000e37 r1538:00000e37 R1538-00000e37 r1538:00000e37 R1538-00000f37
+	// [...]
+	///
+	uint16_t reg = 0x1238 + 0x300; // Port base register for the bits we set
+	for (char i = machine.min_port; i <= machine.max_port; i++) {
+		// Bit 7 (0x40) enables replacement of the RTL-VLAN tag with an 802.1Q VLAN tag
+		REG_SET(reg, 0xe77);
+		reg += 0x100;
+	}
+
+	// r0b7c:000000d8 R0b7c-000000f8 r6040:00000030 R6040-00000031
+	reg_bit_set(0xb7c, 5);
+
+	reg_bit_set(RTL837X_REG_HW_CONF, 0);
+
+
+	// enable EEE for all ports at 2.5G and 10G, but don't reset the PHYs
+	port_eee_enable_all(EEE_2G5 | EEE_NORESET);
+	
+	// TODO: patch the PHYs
+
+	// Re-enable PHY after configuration
+	phy_write_mask(0xf0,PHY_MMD31,0xa610,0x2058);
+
+	// Enables MAC access
+	// Set bits 0xc-0x14 of 0x632c to 0x1f8, see rtl8372_init
+	// r632c:00000540 R632c-001f8540 // RTL8373: 001ff540
+	reg_read_m(0x632c);
+	sfr_mask_data(1, 0x70, 0x80);
+	sfr_mask_data(2, 0x10, 0x1f);
+	reg_write_m(0x632c);
+	print_string("\nrtl8372_init done\n");
+}

--- a/rtl837x_init.h
+++ b/rtl837x_init.h
@@ -1,0 +1,7 @@
+#ifndef _RTL837X_INIT_H_
+#define _RTL837X_INIT_H_
+
+void rtl8372_init(void) __banked;
+void rtl8373_init(void) __banked;
+
+#endif

--- a/rtl837x_stp.c
+++ b/rtl837x_stp.c
@@ -62,7 +62,7 @@ struct stp_pkt_in {
 	uint8_t stp_addr[6];
 	uint8_t src_addr[6];
 	struct rtl_tag rtl_tag;
-	uint8_t vtag[4];
+	struct vlan_tag vlan_tag;
 	uint16_t msg_len;
 	uint8_t dsap;
 	uint8_t ssap;
@@ -82,7 +82,7 @@ struct stp_pkt_in {
 	uint16_t fwd_delay;
 };
 
-#define STP_O ((__xdata struct stp_pkt *)&uip_buf[RTL_TAG_SIZE + VLAN_TAG_SIZE])
+#define STP_O ((__xdata struct stp_pkt *)&uip_buf[RTL_FRAME_DESC_SIZE])
 #define STP_I ((__xdata struct stp_pkt_in *)&uip_buf[0])
 
 #define FLAG_PROPOSAL 0x02
@@ -149,8 +149,8 @@ void stp_cnf_send(uint8_t port)
 	STP_O->stp_addr[0] = 0x01; STP_O->stp_addr[1] = 0x80; STP_O->stp_addr[2] = 0xc2;
 	STP_O->stp_addr[3] = STP_O->stp_addr[4] = STP_O->stp_addr[5] = 0x00;
 
-	STP_O->rtl_tag.tag = HTONS(0x8899);
-	STP_O->rtl_tag.version = 0x04;
+	STP_O->rtl_tag.tag = HTONS(RTL_FRAME_TAG_ID);
+	STP_O->rtl_tag.version = RTL_FRAME_TAG_VERSION;
 	STP_O->rtl_tag.reason = 0x00;
 	STP_O->rtl_tag.flags = 0x0020; // Disable L2 learning
 	STP_O->rtl_tag.pmask = HTONS(((uint16_t)1) << port);

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -149,43 +149,40 @@ struct eth_in {
 	u16_t ether_type;
 };
 
-struct rtl_dot1q_frame {
-	union {
-	struct {
-		uint8_t tx_seq;
-		uint8_t chksum_flags;	// 0x7 enables Checksums for frame header, L2 and L3
-		uint8_t reserved_1 [2];
-		uint16_t len; // Length is Little Endian
-		uint8_t reserved_2 [2];
-		struct uip_eth_addr dst;
-		struct uip_eth_addr src;
-		uint16_t tpid;
-		uint16_t tci;
-	} q_frame;
-	struct {
-		uint8_t padding[VLAN_TAG_SIZE]; // Pad to the size of a RTL-VLAN tag or dot1q-tag
-		uint8_t tx_seq;
-		uint8_t chksum_flags;	// 0x7 enables Checksums for frame header, L2 and L3
-		uint8_t reserved_1 [2];
-		uint16_t len; // Length is Little Endian
-		uint8_t reserved_2 [2];
-		struct uip_eth_addr dst;
-		struct uip_eth_addr src;
-	} nonq_frame;
-	};
-};
-
 // Dot 1Q tag size is the size of tpid + tci
 #define DOT_1Q_TAG_SIZE 4
+
+struct q_frame {
+	uint8_t tx_seq;
+	uint8_t chksum_flags;	// 0x7 enables Checksums for frame header, L2 and L3
+	uint8_t reserved_1 [2];
+	uint16_t len; // Length is Little Endian
+	uint8_t reserved_2 [2];
+	struct uip_eth_addr dst;
+	struct uip_eth_addr src;
+	uint16_t tpid;
+	uint16_t tci;
+};
+
+struct nonq_frame {
+	uint8_t padding[DOT_1Q_TAG_SIZE];
+	uint8_t tx_seq;
+	uint8_t chksum_flags;	// 0x7 enables Checksums for frame header, L2 and L3
+	uint8_t reserved_1 [2];
+	uint16_t len; // Length is Little Endian
+	uint8_t reserved_2 [2];
+	struct uip_eth_addr dst;
+	struct uip_eth_addr src;
+};
 
 #define ETH_IN ((__xdata struct eth_in *)&uip_buf[0])
 #define ETHERTYPE_OFFSET (12 + VLAN_TAG_SIZE + RTL_TAG_SIZE)
 
 // The output frame structure with initial frame descriptor including padding
-#define FRAME (((__xdata struct rtl_dot1q_frame *)&uip_buf[0])->nonq_frame)
+#define FRAME ((__xdata struct nonq_frame *)&uip_buf[0])
 
 // The output frame structure with 802.1Q field and the padding moved before the buffer-start
-#define FRAME_Q (((__xdata struct rtl_dot1q_frame *)&uip_buf[-VLAN_TAG_SIZE])->q_frame)
+#define FRAME_Q ((__xdata struct q_frame *)&uip_buf[0])
 
 void isr_timer0(void) __interrupt(1)
 {
@@ -613,13 +610,13 @@ void nic_tx_packet(uint16_t ring_ptr)
 	 */
 	if (management_vlan) {
 		SFR_NIC_DATA_U16LE = (uint16_t) uip_buf;
-		len = FRAME_Q.len;
+		len = FRAME_Q->len;
 		/*
 		(__xdata struct rtl_dot1q_frame *)uip_buf
 #define FRAME (((__xdata struct rtl_dot1q_frame *)&uip_buf[0]).nonq_frame)*/
 	} else {
 		SFR_NIC_DATA_U16LE = (uint16_t) uip_buf + VLAN_TAG_SIZE;
-		len = FRAME.len;
+		len = FRAME->len;
 	}
 
 #ifdef RXTXDBG
@@ -992,21 +989,21 @@ uint8_t sfp_read_reg(uint8_t slot, uint8_t reg)
 void tcpip_output(void)
 {
 	// Add TX-TAG
-	FRAME.tx_seq = tx_seq++;
-	FRAME.chksum_flags = 0x07;    // Enable all checksums
-	FRAME.reserved_1[0] = 0x00; FRAME.reserved_1[1] = 0x00;
-	FRAME.len = uip_len;
-	FRAME.reserved_2[0] = 0x00; FRAME.reserved_2[1] = 0x00;
+	FRAME->tx_seq = tx_seq++;
+	FRAME->chksum_flags = 0x07;    // Enable all checksums
+	FRAME->reserved_1[0] = 0x00; FRAME->reserved_1[1] = 0x00;
+	FRAME->len = uip_len;
+	FRAME->reserved_2[0] = 0x00; FRAME->reserved_2[1] = 0x00;
 
 	// For the management VLAN we insert an 802.1Q VLAN tag
 	if (management_vlan) {
 		// Shift the ethernet header before the HW type including the rtl_frame_desc to the beginning of uip_buf
 		// to allow space to insert the dot 1Q tag
-		for (uint8_t i = 0; i < sizeof(struct rtl_dot1q_frame) - (VLAN_TAG_SIZE * 2); i++)
+		for (uint8_t i = 0; i < sizeof(struct q_frame) - DOT_1Q_TAG_SIZE; i++)
 			uip_buf[i] = uip_buf[i + DOT_1Q_TAG_SIZE];
-		FRAME_Q.len += DOT_1Q_TAG_SIZE;
-		FRAME_Q.tpid = HTONS(0x8100);  // Change ether-type to Dot1Q
-		FRAME_Q.tci = HTONS(management_vlan);
+		FRAME_Q->len += DOT_1Q_TAG_SIZE;
+		FRAME_Q->tpid = HTONS(0x8100);  // Change ether-type to Dot1Q
+		FRAME_Q->tci = HTONS(management_vlan);
 	}
 
 	reg_read_m(RTL837X_REG_CPU_TX_CURR_PKT);
@@ -1062,6 +1059,7 @@ void handle_rx(void)
 		print_string(" RX-VLAN: "); print_short(rx_packet_vlan); write_char('\n');
 		print_string(" RX dst: "); print_byte(uip_buf[0]); print_byte(uip_buf[1]); print_byte(uip_buf[2]);
 		print_byte(uip_buf[3]); print_byte(uip_buf[4]); print_byte(uip_buf[5]); write_char('\n');
+		print_string(" MGMT-VLAN: "); print_short(management_vlan); write_char('\n');
 #endif
 		if (stpEnabled && uip_buf[0] == 0x01 && uip_buf[1] == 0x80 && uip_buf[2] == 0xc2 // STP packet?
 			&& uip_buf[3] == 0x00 && uip_buf[4] == 0x00 && uip_buf[5] == 0x00) {
@@ -2014,7 +2012,7 @@ void main(void)
 	uip_arp_init();
 	httpd_init();
 
-	management_vlan = 0; // Disabled
+	management_vlan = 1; // Default management VLAN is 1
 
 	setup_i2c();
 	setup_sfp_gpio();

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -15,6 +15,7 @@
 #include "rtl837x_igmp.h"
 #include "rtl837x_leds.h"
 #include "rtl837x_bandwidth.h"
+#include "rtl837x_init.h"
 #include "dhcp.h"
 #include "cmd_parser.h"
 #include "cmd_editor.h"
@@ -140,7 +141,51 @@ __xdata bool button_last;
 __xdata uint8_t button_sec_counter_last;
 volatile __bit tx_buf_empty;
 
+struct eth_in {
+	struct uip_eth_addr dst;
+	struct uip_eth_addr src;
+	struct rtl_tag rtl_tag;
+	struct vlan_tag vlan_tag;
+	u16_t ether_type;
+};
+
+struct rtl_dot1q_frame {
+	union {
+	struct {
+		uint8_t tx_seq;
+		uint8_t chksum_flags;	// 0x7 enables Checksums for frame header, L2 and L3
+		uint8_t reserved_1 [2];
+		uint16_t len; // Length is Little Endian
+		uint8_t reserved_2 [2];
+		struct uip_eth_addr dst;
+		struct uip_eth_addr src;
+		uint16_t tpid;
+		uint16_t tci;
+	} q_frame;
+	struct {
+		uint8_t padding[VLAN_TAG_SIZE]; // Pad to the size of a RTL-VLAN tag or dot1q-tag
+		uint8_t tx_seq;
+		uint8_t chksum_flags;	// 0x7 enables Checksums for frame header, L2 and L3
+		uint8_t reserved_1 [2];
+		uint16_t len; // Length is Little Endian
+		uint8_t reserved_2 [2];
+		struct uip_eth_addr dst;
+		struct uip_eth_addr src;
+	} nonq_frame;
+	};
+};
+
+// Dot 1Q tag size is the size of tpid + tci
+#define DOT_1Q_TAG_SIZE 4
+
+#define ETH_IN ((__xdata struct eth_in *)&uip_buf[0])
 #define ETHERTYPE_OFFSET (12 + VLAN_TAG_SIZE + RTL_TAG_SIZE)
+
+// The output frame structure with initial frame descriptor including padding
+#define FRAME (((__xdata struct rtl_dot1q_frame *)&uip_buf[0])->nonq_frame)
+
+// The output frame structure with 802.1Q field and the padding moved before the buffer-start
+#define FRAME_Q (((__xdata struct rtl_dot1q_frame *)&uip_buf[-VLAN_TAG_SIZE])->q_frame)
 
 void isr_timer0(void) __interrupt(1)
 {
@@ -558,15 +603,38 @@ void nic_rx_packet(register uint16_t buffer, register uint16_t ring_ptr)
  */
 void nic_tx_packet(uint16_t ring_ptr)
 {
-//	uint16_t buffer = (uint16_t) tx_buf;
-	uint16_t buffer = (uint16_t) uip_buf + VLAN_TAG_SIZE;
-	SFR_NIC_DATA_U16LE = buffer;
-	
+	uint16_t len;
+
+	/* If we have a management VLAN, we have inserted a dot1Q-tag into the frame and
+	 * the frame starts at the beginning of uip_buf with the RTL TX descriptor,
+	 * otherwise the frame is a normal Ethernet frame which starts with
+	 * an RTL TX descriptor being padded at the beginning, in the second case
+	 * we need to skip the padding for the sending of the frame.
+	 */
+	if (management_vlan) {
+		SFR_NIC_DATA_U16LE = (uint16_t) uip_buf;
+		len = FRAME_Q.len;
+		/*
+		(__xdata struct rtl_dot1q_frame *)uip_buf
+#define FRAME (((__xdata struct rtl_dot1q_frame *)&uip_buf[0]).nonq_frame)*/
+	} else {
+		SFR_NIC_DATA_U16LE = (uint16_t) uip_buf + VLAN_TAG_SIZE;
+		len = FRAME.len;
+	}
+
+#ifdef RXTXDBG
+	print_string("TX: \n");
+	for (uint8_t i = 0; i < 100; i++) {
+		print_byte(uip_buf[i]);
+		write_char(' ');
+	}
+	write_char('\n');
+#endif
+
 	ring_ptr <<= 3;
 	ring_ptr |= 0x8000;
 	SFR_NIC_RING_U16LE = ring_ptr;
-	
-	uint16_t len = (((uint16_t)uip_buf[VLAN_TAG_SIZE + 5]) << 8) | uip_buf[VLAN_TAG_SIZE + 4];
+
 	len += 0xf;
 	len >>= 3;
 	SFR_NIC_CTRL = len;
@@ -924,25 +992,26 @@ uint8_t sfp_read_reg(uint8_t slot, uint8_t reg)
 void tcpip_output(void)
 {
 	// Add TX-TAG
-	uip_buf[VLAN_TAG_SIZE] = tx_seq++;
-	uip_buf[VLAN_TAG_SIZE + 1] = 0x07;    // Enable all checksums
-	uip_buf[VLAN_TAG_SIZE + 5] = uip_len >> 8;
-	uip_buf[VLAN_TAG_SIZE + 4] = uip_len;
-	uip_buf[VLAN_TAG_SIZE + 2] = uip_buf[VLAN_TAG_SIZE + 3] = 0;
-	uip_buf[VLAN_TAG_SIZE + 6] = uip_buf[VLAN_TAG_SIZE + 7] = 0;
+	FRAME.tx_seq = tx_seq++;
+	FRAME.chksum_flags = 0x07;    // Enable all checksums
+	FRAME.reserved_1[0] = 0x00; FRAME.reserved_1[1] = 0x00;
+	FRAME.len = uip_len;
+	FRAME.reserved_2[0] = 0x00; FRAME.reserved_2[1] = 0x00;
+
+	// For the management VLAN we insert an 802.1Q VLAN tag
+	if (management_vlan) {
+		// Shift the ethernet header before the HW type including the rtl_frame_desc to the beginning of uip_buf
+		// to allow space to insert the dot 1Q tag
+		for (uint8_t i = 0; i < sizeof(struct rtl_dot1q_frame) - (VLAN_TAG_SIZE * 2); i++)
+			uip_buf[i] = uip_buf[i + DOT_1Q_TAG_SIZE];
+		FRAME_Q.len += DOT_1Q_TAG_SIZE;
+		FRAME_Q.tpid = HTONS(0x8100);  // Change ether-type to Dot1Q
+		FRAME_Q.tci = HTONS(management_vlan);
+	}
 
 	reg_read_m(RTL837X_REG_CPU_TX_CURR_PKT);
 	uint16_t ring_ptr = ((uint16_t)sfr_data[2]) << 8;
 	ring_ptr |= sfr_data[3];
-
-#ifdef RXTXDBG
-	print_string("TX: \n");
-	for (uint8_t i = 0; i < 120; i++) {
-		print_byte(uip_buf[i]);
-		write_char(' ');
-	}
-	write_char('\n');
-#endif
 
 	// Move data over from xmem buffer to ASIC side using DMA
 	nic_tx_packet(ring_ptr);
@@ -987,10 +1056,8 @@ void handle_rx(void)
 		REG_SET(RTL837X_REG_NIC_RXCMD, 1);
 		uip_len = (((uint16_t)rx_headers[5]) << 8) | rx_headers[4];
 
-		// Retrieve VLAN from VLAN-tag
-		rx_packet_vlan = uip_buf[2 * sizeof (struct uip_eth_addr) + RTL_TAG_SIZE + 2] & 0xf;
-		rx_packet_vlan <<= 8;
-		rx_packet_vlan |= uip_buf[2 * sizeof (struct uip_eth_addr) + RTL_TAG_SIZE + 3];
+		rx_packet_vlan = NTOHS(ETH_IN->vlan_tag.vlan) & 0x0fff;
+
 #ifdef RXTXDBG
 		print_string(" RX-VLAN: "); print_short(rx_packet_vlan); write_char('\n');
 		print_string(" RX dst: "); print_byte(uip_buf[0]); print_byte(uip_buf[1]); print_byte(uip_buf[2]);
@@ -1009,12 +1076,12 @@ void handle_rx(void)
 			if (uip_len) {
 				tcpip_output();
 			}
-		} else if (uip_buf[ETHERTYPE_OFFSET] == 0x08 && uip_buf[ETHERTYPE_OFFSET + 1] == 0x06) { // ARP?
+		} else if (ETH_IN->ether_type == HTONS(0x0806)) { // ARP
 			uip_arp_arpin();
 			if (uip_len) {
 			    tcpip_output();
 			}
-		} else if (uip_buf[ETHERTYPE_OFFSET] == 0x08 && uip_buf[ETHERTYPE_OFFSET + 1] == 0x00) { // TCP?
+		} else if (ETH_IN->ether_type == HTONS(0x0800)) { // IPv4
 			if (!management_vlan || management_vlan == rx_packet_vlan) {
 				uip_arp_ipin();	// Learn MAC addresses in TCP packets
 				uip_input();
@@ -1537,78 +1604,6 @@ void nic_setup(void)
 }
 
 
-/*
- * Configure the PHY-Side of the SDS-SDS link between SoC and PHY
- */
-void sds_init(void)
-{
-/*
-	p001e.000d:9535 R02f8-00009535 R02f4-0000953a P000001.1e00000d:953a
-	p001e.000d:953a p001e.000d:953a R02f8-0000953a R02f4-00009530 P000001.1e00000d:9530
-
-	RTL8373:
-	p001e.000d:0010 R02f8-00000010 R02f4-0000001a P000001.1e00000d:b7fe
-	p001e.000d:0010 p001e.000d:0010	R02f8-00000010 R02f4-00000010 P000001.1e00000d:b7fe
-*/
-	phy_read(0, PHY_MMD30, 0xd);
-	uint16_t pval = SFR_DATA_U16;
-
-	// PHY Initialization:
-	REG_WRITE(0x2f8, 0, 0, pval >> 8, pval);
-	delay(20);
-
-	pval &= 0xfff0;
-	pval |= 0x0a;
-	REG_WRITE(0x2f4, 0, 0, pval >> 8, pval);
-	delay(10);
-
-	phy_write_mask(0x1, PHY_MMD30, 0xd, pval);
-
-	phy_read(0, PHY_MMD30, 0xd);
-	pval = SFR_DATA_U16;
-
-	REG_WRITE(0x2f8, 0, 0, pval >> 8, pval);
-
-	pval &= 0xfff0;
-	REG_WRITE(0x2f4, 0, 0, pval >> 8, pval);
-
-	phy_write_mask(0x1, PHY_MMD30, 0xd, pval);
-
-	if (machine_detected.isN) {
-		uint16_t pval;
-
-		print_string("  N-settings");
-		// Serdes 0 RX PN swap for 64B/66B
-		sds_read(1, 6, 2);
-		pval = SFR_DATA_U16;
-		sds_write_v(1, 6, 2, pval | 0x2000);
-
-		// Serdes 1 RX PN swap for 8B/10B
-		sds_read(1, 0, 0);
-		pval = SFR_DATA_U16;
-		sds_write_v(1, 0, 0, pval | 0x200);
-
-		// Serdes 0 RX PN swap for 64B/66B
-		sds_read(0, 6, 2);
-		pval = SFR_DATA_U16;
-		sds_write_v(0, 6, 2, pval | 0x2000);
-
-		if (machine_detected.isRTL8373) {
-			// RTL8224: Serdes 0 RX PN swap for 64B/66B
-			// We assume that RTL8373N always paired with RTL8224N.
-			// This sds register value is 0x0000 at reset.
-			// So only write to it.
-			RTL8224_SDS_WRITE(0, 6, 2, 0x2000);
-		} else {
-			// Serdes 0 RX PN swap for 8B/10B
-			sds_read(0, 0, 0);
-			pval = SFR_DATA_U16;
-			sds_write_v(0, 0, 0, pval | 0x200);
-		}
-	}
-}
-
-
 void set_sys_led_state(uint8_t state)
 {
 	reg_read_m(RTL837X_REG_LED_MODE);
@@ -1627,167 +1622,6 @@ void rtl8373_revision(void)
 	print_string("CPU revision: "); print_byte(sfr_data[2]); print_byte(sfr_data[2]); write_char('\n');
 	sfr_mask_data(2, 0x0a, 0x00); 	// Enable reading version
 	reg_write_m(RTL837X_REG_CHIP_INFO);
-}
-
-
-void rtl8373_init(void)
-{
-	print_string("\nrtl8373_init called\n");
-
-	// r65d8:3ffbedff R65d8-3ffbedff
-	reg_bit_set(0x65d8, 0x1d);
-
-	sds_init();
-	// Disable all SERDES for configuration
-	REG_SET(RTL837X_REG_SDS_MODES, 0x000037ff);
-
-	// q000601:c800 Q000601:c804 q000601:c804 Q000601:c800
-	sds_read(0, 0x06, 0x01);
-	uint16_t pval = SFR_DATA_U16;
-	sds_write_v(0, 0x06, 0x01, pval | 0x04);
-	delay(50);
-	sds_read(0, 0x06, 0x01);
-	pval = SFR_DATA_U16;
-	sds_write_v(0, 0x06, 0x01, pval & 0xfffb);
-
-	phy_config_8224();
-	sds_config_mac(1, SDS_OFF);    // Off for now until SFP+ port used
-	sds_config_mac(2, SDS_SGMII);  // For RTL8224
-	sds_config(0, SDS_QXGMII);
-
-	// SDS 1 setup
-	// q012100:4902 Q012100:4906 q013605:0000 Q013605:4000 Q011f02:001f q011f15:0086
-	sds_write_v(1, 0x21, 0x00, 0x4906);
-	sds_write_v(1, 0x36, 0x05, 0x4000);
-	sds_write_v(1, 0x1f, 0x02, 0x001f);
-	sds_read(1, 0x1f, 0x15);
-	pval = SFR_DATA_U16;
-
-	// r0a90:000000f3 R0a90-000000fc
-	reg_read_m(RTL837X_CFG_PHY_MDI_REVERSE);
-	sfr_mask_data(0, 0x0f,0x0c);
-	reg_write_m(RTL837X_CFG_PHY_MDI_REVERSE);
-
-	if (machine_detected.isN) {
-		print_string("  TX_POLARITY_SWAP\n");
-		// FOR N-Version: #TX_POLARITY_SWAP
-		reg_read_m(RTL837X_CFG_PHY_TX_POLARITY_SWAP);
-			sfr_data[2] = 0x59;
-			sfr_data[3] = 0x6a;
-		reg_write_m(RTL837X_CFG_PHY_TX_POLARITY_SWAP);
-	}
-
-	rtl8224_phy_enable();
-
-	// Disable PHYs for configuration
-	phy_write_mask(0xff,PHY_MMD31,0xa610,0x2858);
-
-	// Set bits 0x13 and 0x14 of 0x5fd4
-	// r5fd4:0002914a R5fd4-001a914a
-	reg_bit_set(0x5fd4, 0x13);
-	reg_bit_set(0x5fd4, 0x14);
-
-	// Configure ports
-	uint16_t reg = 0x1238; // Port base register for the bits we set
-	for (char i = 0; i < 9; i++) {
-		// Bit 7 (0x40) enables replacement of the RTL-VLAN tag with an 802.1Q VLAN tag
-		REG_SET(reg, 0xe77);
-		reg += 0x100;
-	}
-
-	// r0b7c:000000d8 R0b7c-000000f8 r6040:00000030 R6040-00000031
-	reg_bit_set(0xb7c, 5);
-
-	// R7124-00001050 R7128-00001050 R712c-00001050 R7130-00001050 R7134-00001050 R7138-00001050
-	// R713c-00001050 R7140-00001050 R7144-00001050 R7148-00001050
-	REG_SET(0x7124, 0x1050); REG_SET(0x7128, 0x1050); REG_SET(0x712c, 0x1050);
-	REG_SET(0x7130, 0x1050); REG_SET(0x7134, 0x1050); REG_SET(0x7138, 0x1050);
-	REG_SET(0x713c, 0x1050); REG_SET(0x7140, 0x1050); REG_SET(0x7144, 0x1050);
-	REG_SET(0x7148, 0x1050);
-
-	reg_bit_set(RTL837X_REG_HW_CONF, 0);
-
-	// enable EEE for all ports at 2.5G and 10G, but don't reset the PHYs
-	port_eee_enable_all(EEE_2G5 | EEE_NORESET);
-
-	// TODO: patch the PHYs
-
-	// Re-enable PHY after configuration
-	phy_write_mask(0xff,PHY_MMD31,0xa610,0x2058);
-
-	// Enables MAC access
-	// Set bits 0xc-0x14 of 0x632c to 0x1f8, see rtl8372_init
-	// r632c:00000540 R632c-001f8540 // RTL8373: 001ff540
-	reg_read_m(0x632c);
-	sfr_mask_data(1, 0x70, 0xf0); // The ports of the RTL8824
-	sfr_mask_data(2, 0x10, 0x1f);
-	reg_write_m(0x632c);
-
-	print_string("\nrtl8373_init done\n");
-}
-
-
-void rtl8372_init(void)
-{
-	print_string("\nrtl8372_init called\n");
-
-	sds_init();
-	phy_config(8);	// PHY configuration: External 8221B?
-	phy_config(3);	// PHY configuration: all internal PHYs?
-	// Set the MAC SerDes Modes Bits 0-4: SDS 0 = 0x2 (0x2), Bits 5-9: SDS 1: 1f (off)
-	// r7b20:00000bff R7b20-00000bff r7b20:00000bff R7b20-00000bff r7b20:00000bff R7b20-000003ff r7b20:000003ff R7b20-000003e2 r7b20:000003e2 R7b20-000003e2
-	reg_read_m(RTL837X_REG_SDS_MODES);
-	sfr_mask_data(1, 0, 0x03);
-	sfr_mask_data(0, 0, 0xe2);
-	reg_write_m(RTL837X_REG_SDS_MODES);
-
-	// r0a90:000000f3 R0a90-000000fc
-	reg_read_m(RTL837X_CFG_PHY_MDI_REVERSE);
-	sfr_mask_data(0, 0x0f, 0x0c);
-	reg_write_m(RTL837X_CFG_PHY_MDI_REVERSE);
-
-	// Disable PHYs for configuration
-	phy_write_mask(0xf0,PHY_MMD31,0xa610,0x2858);
-
-	// Set bits 0x13 and 0x14 of 0x5fd4
-	// r5fd4:0002914a R5fd4-001a914a
-	reg_bit_set(0x5fd4, 0x13);
-	reg_bit_set(0x5fd4, 0x14);
-
-	// Configure ports 3-8:
-	//
-	// r1538:00000e33 R1538-00000e37 r1538:00000e37 R1538-00000e37 r1538:00000e37 R1538-00000f37
-	// [...]
-	///
-	uint16_t reg = 0x1238 + 0x300; // Port base register for the bits we set
-	for (char i = machine.min_port; i <= machine.max_port; i++) {
-		// Bit 7 (0x40) enables replacement of the RTL-VLAN tag with an 802.1Q VLAN tag
-		REG_SET(reg, 0xe77);
-		reg += 0x100;
-	}
-
-	// r0b7c:000000d8 R0b7c-000000f8 r6040:00000030 R6040-00000031
-	reg_bit_set(0xb7c, 5);
-
-	reg_bit_set(RTL837X_REG_HW_CONF, 0);
-
-
-	// enable EEE for all ports at 2.5G and 10G, but don't reset the PHYs
-	port_eee_enable_all(EEE_2G5 | EEE_NORESET);
-	
-	// TODO: patch the PHYs
-
-	// Re-enable PHY after configuration
-	phy_write_mask(0xf0,PHY_MMD31,0xa610,0x2058);
-
-	// Enables MAC access
-	// Set bits 0xc-0x14 of 0x632c to 0x1f8, see rtl8372_init
-	// r632c:00000540 R632c-001f8540 // RTL8373: 001ff540
-	reg_read_m(0x632c);
-	sfr_mask_data(1, 0x70, 0x80);
-	sfr_mask_data(2, 0x10, 0x1f);
-	reg_write_m(0x632c);
-	print_string("\nrtl8372_init done\n");
 }
 
 

--- a/uip/uip.h
+++ b/uip/uip.h
@@ -1070,8 +1070,10 @@ __xdata struct uip_udp_conn *uip_udp_new(__xdata uip_ipaddr_t *ripaddr, __xdata 
 #ifndef HTONS
 #   if UIP_BYTE_ORDER == UIP_BIG_ENDIAN
 #      define HTONS(n) (n)
+#      define NTOHS(n) (n)
 #   else /* UIP_BYTE_ORDER == UIP_BIG_ENDIAN */
 #      define HTONS(n) (u16_t)((((u16_t) (n)) << 8) | (((u16_t) (n)) >> 8))
+#      define NTOHS(n) (u16_t)((((u16_t) (n)) << 8) | (((u16_t) (n)) >> 8))
 #   endif /* UIP_BYTE_ORDER == UIP_BIG_ENDIAN */
 #else
 #error "HTONS already defined!"

--- a/uip/uip_arp.c
+++ b/uip/uip_arp.c
@@ -68,7 +68,8 @@
 
 struct arp_hdr_i {
   struct uip_eth_hdr ethhdr;
-  uint8_t rtl_tag[RTL_TAG_SIZE + VLAN_TAG_SIZE];
+  struct rtl_tag rtl_tag;
+  struct vlan_tag vlan_tag;
   u16_t hwtype;
   u16_t protocol;
   u8_t hwlen;
@@ -131,8 +132,8 @@ static __xdata u8_t arptime;
 static __xdata u8_t tmpage;
 
 #define BUF   ((__xdata struct arp_hdr_i *)&uip_buf[0])
-#define BUF_O ((__xdata struct arp_hdr_o *)&uip_buf[RTL_TAG_SIZE + VLAN_TAG_SIZE])
-#define IPBUF ((__xdata struct ethip_hdr *)&uip_buf[RTL_TAG_SIZE + VLAN_TAG_SIZE])
+#define BUF_O ((__xdata struct arp_hdr_o *)&uip_buf[RTL_FRAME_DESC_SIZE])
+#define IPBUF ((__xdata struct ethip_hdr *)&uip_buf[RTL_FRAME_DESC_SIZE])
 /*-----------------------------------------------------------------------------------*/
 /**
  * Initialize the ARP module.

--- a/uip/uipopt.h
+++ b/uip/uipopt.h
@@ -447,7 +447,7 @@ void uip_log(char *msg);
 #ifdef UIP_CONF_LLH_LEN
 #define UIP_LLH_LEN UIP_CONF_LLH_LEN
 #else /* UIP_CONF_LLH_LEN */
-#define UIP_LLH_LEN     ETHER_HEADER_SIZE + RTL_TAG_SIZE + VLAN_TAG_SIZE
+#define UIP_LLH_LEN     ETHER_HEADER_SIZE + RTL_FRAME_DESC_SIZE
 #endif /* UIP_CONF_LLH_LEN */
 
 /** @} */


### PR DESCRIPTION
The frame header structure has been mostly magic offsets so far. Add a TX frame descriptor structure and use structures to access the frame descriptor and the frames for TX and RX as well as for assembly of packets.

uIP uses the same buffer for receiving packets as well as for transmitting them, and requires that the application data is aligned in memory for TX and RX packets, so that in some cases data is not even copied over from a request packet into a reply packet. Also the sequence of copying of information requires this alignment. The start of the application data for TX and RX packets is therefore always aligned.

The RTL837x SoCs require a frame descriptor at the beginning of any packet to be sent. This descriptor has a size of 8 bytes. When a packet is received, the RX descriptor can be placed in any memory location and is not part of the frame buffer. Instead, the frame starts directly with the Ethernet frame, which however includes at least an RTL tag (8 bytes) plus optionally 4 bytes for an RTL VLAN tag (2 bytes service VLAN, 2 bytes inner VLAN). Since VLAN support is enabled in our case, the VLAN tag is always present. Because the application data start is fixed, this means that for TX packets we do not need the full memory space from the start of the uip_buffer to the application buffer start when sending normal Ethernet frames. Instead there are 4 buffer bytes at the beginning, which we skip when handing the TX descriptor to the ASIC.. When sending management frames, we insert a dot1Q tag (4 bytes) into the Ethernet frame and push the TX frame descriptor with its initial padding over the beginning of the uip_buffer, so that the frame starts with the actual frame descriptor.

Management VLAN is fixed by inserting a dot1q tag with the management frame. If we are using an untagged management port, the tag is removed by the switch engine, the management device does not see that tag.