### PR TITLE
Workaround for build problem that leads to BANK0 overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ create_build_dir:
 	mkdir -p $(BUILDDIR)
 	mkdir -p $(BUILDDIR)/uip
 	mkdir -p $(BUILDDIR)/httpd
+	rm -f html_data.c
+#   ^^^ rm -rf html_data.c is a workaround. For some reason, the bank0 gets too much data if this file already exists when running make without clean
 
 SRCS = rtlplayground.c rtl837x_flash.c rtl837x_leds.c rtl837x_phy.c rtl837x_port.c cmd_parser.c html_data.c rtl837x_igmp.c
 SRCS += rtl837x_stp.c rtl837x_pins.c dhcp.c machine.c cmd_editor.c rtl837x_bandwidth.c


### PR DESCRIPTION
Without this workaround `make clean; make` does work, while `make; make` does not: `Error: Bank 0: code segment too large at 0x4009!`

Of course it would be better to find the real magic why this happens and fix the root cause. 