### PR TITLE
Improve compatibility with 2.5G SFP modules

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -997,7 +997,7 @@ static inline uint8_t sfp_rate_to_sds_config(register uint8_t rate)
 {
 	if (rate == 0xd)
 		return SDS_1000BX_FIBER;
-	if (rate == 0x1f)  // Ethernet 2.5 GBit
+	if (rate >= 0x19 && rate <= 0x20)  // Ethernet 2.5 GBit
 		return SDS_HSG;
 	if (rate > 0x65 && rate < 0x70)
 		return SDS_10GR;


### PR DESCRIPTION
Some modules might report a nominal bitrate of 2500 Mbd or 3200 Mbd instead of 3100 Mbd. Accept the entire range to make them work.