### PR TITLE
Make sure that the output of all commands ends with a newline

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -252,7 +252,7 @@ void parse_lag(void)
 	port_lag_members_set(group, members);
 	return;
 err:
-	print_string("Error: lag <lag> [port]...");
+	print_string("Error: lag <lag> [port]...\n");
 }
 
 
@@ -354,7 +354,7 @@ void parse_vlan(void)
 	}
 	return;
 err:
-	print_string("Error: vlan (<vlan-id>|show) [port][t/u]...");
+	print_string("Error: vlan (<vlan-id>|show) [port][t/u]...\n");
 }
 
 bool vlan_ingress_mode_parse(char c, vlan_ingress_mode_t *mode)
@@ -455,7 +455,7 @@ void parse_mirror(void)
 	}
 
 	if (!isnumber(cmd_buffer[cmd_words_b[1]])) {
-		print_string("Port missing: mirror <mirroring port> [port][t/r]...");
+		print_string("Port missing: mirror <mirroring port> [port][t/r]...\n");
 		return;
 	}
 
@@ -580,7 +580,7 @@ void parse_mtu(void)
 	p = machine.phys_to_log_port[p];
 	print_byte(p);
 	if (cmd_words_b[2] <= 0) {
-		print_string("mtu [port] [size]");
+		print_string("mtu [port] [size]\n");
 		return;
 	}
 	atoi_short(&mtu, cmd_words_b[2]);
@@ -590,6 +590,7 @@ void parse_mtu(void)
 	}
 	REG_WRITE(RTL8373_REG_MAC_L2_PORT_MAX_LEN + ((uint16_t) p << 8), (mtu >> 10) & 0xf, (mtu >> 2) & 0xff,
 		  ((mtu & 0x3) << 6) | ((mtu >> 8) & 0x3f), mtu & 0xff);
+	write_char('\n');
 }
 
 void sfp_print_measurements(uint8_t sfp)
@@ -633,6 +634,7 @@ void parse_regget(void)
 
 	reg_read_m(reg);
 	print_sfr_data();
+	write_char('\n');
 	return;
 
 err:
@@ -681,6 +683,7 @@ void parse_regset(void)
 
 	print_string(": VAL: ");
 	print_sfr_data();
+	write_char('\n');
 	return;
 
 err:
@@ -1079,6 +1082,7 @@ void cmd_parser(void) __banked
 			parse_lag_hash();
 		} else if (cmd_compare(0, "sds")) {
 			print_reg(RTL837X_REG_SDS_MODES);
+			write_char('\n');
 		} else if (cmd_compare(0, "gpio")) {
 			print_gpio_status();
 		} else if (cmd_compare(0, "regget")) {

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -35,6 +35,7 @@ void port_mirror_set(register uint8_t port, __xdata uint16_t rx_pmask, __xdata u
 	print_string("\nport_mirror_set called \n");
 	print_string("Mirroring port: "); print_byte(port); print_string(" with rx-mask: ");
 	print_short(rx_pmask); print_string(", tx mask: "); print_short(tx_pmask);
+	write_char('\n');
 
 	REG_WRITE(RTL837x_MIRROR_CONF, rx_pmask >> 8, rx_pmask, tx_pmask >> 8, tx_pmask);
 	REG_WRITE(RTL837x_MIRROR_CTRL, 0, 0, 0, (port << 1) | 0x1);
@@ -640,8 +641,9 @@ void port_rldp_on(__xdata uint16_t p_ms)
 void port_lag_members_set(__xdata uint8_t lag, __xdata uint16_t members) __banked
 {
 	print_string("port_lag_members_set, lag: "); print_byte(lag); print_string(", members: "); print_short(members);
+	write_char('\n');
 	if (lag > 3)
-		print_string("Link aggregation group must be 0-3!");
+		print_string("Link aggregation group must be 0-3!\n");
 	reg_read_m(RTL837X_TRK_HASH_CTRL_BASE + (lag << 2));
 	if (!(sfr_data[0] | sfr_data [1] | sfr_data [2] | sfr_data [3]))
 		REG_SET(RTL837X_TRK_HASH_CTRL_BASE, LAG_HASH_DEFAULT);
@@ -656,8 +658,9 @@ void port_lag_members_set(__xdata uint8_t lag, __xdata uint16_t members) __banke
 void port_lag_hash_set(__xdata uint8_t lag, __xdata uint8_t hash_bits) __banked
 {
 	print_string("port_lag_hash_set, lag: "); print_byte(lag); print_string(", hash: "); print_byte(hash_bits);
+	write_char('\n');
 	if (lag > 3)
-		print_string("Link aggregation group must be 0-3!");
+		print_string("Link aggregation group must be 0-3!\n");
 	REG_WRITE(RTL837X_TRK_HASH_CTRL_BASE + (lag << 2), 0, 0, 0, hash_bits);
 }
 


### PR DESCRIPTION
For now this is mostly cosmetic. But for #148, it would fix the issue that some commands don't get sent to syslog immediately.

Tested only with the syslog PR, as I don't currently have an unused device with serial port available.