### PR TITLE
Add DHCP server, RLDP loop detection, and Services web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A Playground for Firmware development for advanced user of RTL8372/RTL8373 based
 For each hardware configuration of these devices, there is usually a managed and an
 umanaged version sold, with mostly identical hardware. The aim is to provide management
 features also for unmanaged devices with additional features such as Management VLAN,
-dhcp servers, multi-language support, IPv6 and TLS-encrypted web-pages. At present, however
-only the following features are provided:
+dhcp servers, multi-language support, IPv6 and TLS-encrypted web-pages. At present, the
+following features are provided:
 - A modern web-interface with mouse-over to display further information
 - A serial console interface to configure all features
 - IGMP to configure Multicast streaming
@@ -15,22 +15,30 @@ only the following features are provided:
   for particular devices
 - EEE (Energy Efficient Ethernet) can be configured per-port. Detailed information is
   provided for support offered by the link partner and the EEE status of a port.
-- VLAN configuration
+- VLAN configuration including an optional Management VLAN that restricts access
+  to the web/CLI management interface to a single tagged VLAN
 - SFP information is displayed on the inserted modules, the current sensor values such as
   temperatures, RX and TX power are displayed in the CLI and as mouse-over on the web
 - Mirror configuration
 - Link Aggregation Groups can be set up
 - Detailed information on port packet statistics
+- Spanning Tree Protocol (RSTP) can be enabled/disabled from the serial console and
+  the Services tab of the web-interface
+- Loop detection using Realtek's loop detection protocol (RLDP) with a configurable
+  probe interval, controllable from the serial console and the web-interface
+- A minimal integrated DHCP server that hands out leases from a configurable pool
+  on the management subnet; useful for unmanaged devices that need to bootstrap an
+  isolated test network
+- A DHCP client that can automatically obtain the management IP address
 - Configuration saved to flash via the web-interface
 - Firmware updates via the web
 - Installation as a firmware upgrade from the original web-interface
 
 <img width="1420" height="623" alt="GUI" src="doc/images/gui.png" />
 
-While the firmware provides already considerable improvements over the original managed firmware,
-the firmware still lacks support for STP and the proprietary loop prevention
-protocols as well as DHCP. If you need these features, do not install the playground on your managed
-devices. In any case, installation is strongly discouraged unless you can at least make
+While the firmware provides already considerable improvements over the original managed
+firmware, it still lacks support for IPv6, TLS-encrypted web pages and multi-language
+support. In any case, installation is strongly discouraged unless you can at least make
 a backup of the original flash content via a SOIC clamp such as also used for BIOS
 backups and can re-install that firmware in case something is wrong. For this no soldering
 skills are necessary.

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -40,6 +40,7 @@ extern __xdata struct flash_region_t flash_region;
 extern __xdata char passwd[21];
 
 extern __xdata struct dhcp_state dhcp_state;
+extern __xdata struct dhcpd_state dhcpd_state;
 
 __xdata uint8_t vlan_names[VLAN_NAMES_SIZE];
 __xdata uint16_t vlan_ptr;
@@ -1279,6 +1280,62 @@ void cmd_parser(void) __banked
 				print_string("STP disabled\n");
 				stp_off();
 				stpEnabled = 0;
+			}
+		} else if (cmd_compare(0, "dhcpd")) {
+			// Integrated DHCP server control:
+			//   dhcpd on [<first-octet>] [<count>] [<lease-seconds>]
+			//   dhcpd off
+			//   dhcpd status
+			if (cmd_compare(1, "on")) {
+				if (cmd_words_b[2] > 0) {
+					__xdata uint8_t first = 100;
+					__xdata uint8_t count = 8;
+					atoi_byte(&first, cmd_words_b[2]);
+					if (cmd_words_b[3] > 0)
+						atoi_byte(&count, cmd_words_b[3]);
+					dhcpd_set_pool(first, count);
+				}
+				if (cmd_words_b[4] > 0) {
+					__xdata uint16_t secs;
+					if (!atoi_short(&secs, cmd_words_b[4]))
+						dhcpd_set_lease_time((uint32_t)secs);
+				}
+				dhcpd_start();
+			} else if (cmd_compare(1, "off")) {
+				dhcpd_stop();
+			} else {
+				print_string("DHCP server ");
+				if (dhcpd_state.enabled) {
+					print_string("running, pool .");
+					print_byte(dhcpd_state.pool_first); print_string(" +");
+					print_byte(dhcpd_state.pool_count);
+					print_string(", leases in use: "); print_byte(dhcpd_active_leases());
+				} else {
+					print_string("stopped");
+				}
+				write_char('\n');
+			}
+		} else if (cmd_compare(0, "lbd")) {
+			// Loop detection (RLDP) control:
+			//   lbd on [<timer-ms>]    - enable with optional interval (default 1000 ms)
+			//   lbd off                - disable
+			//   lbd status             - show current timer value
+			if (cmd_compare(1, "on")) {
+				__xdata uint16_t ms = 1000;
+				if (cmd_words_b[2] > 0)
+					atoi_short(&ms, cmd_words_b[2]);
+				port_rldp_on(ms);
+				print_string("Loop detection enabled, timer "); print_short(ms); print_string(" ms\n");
+			} else if (cmd_compare(1, "off")) {
+				port_rldp_off();
+				print_string("Loop detection disabled\n");
+			} else {
+				__xdata uint16_t t = port_rldp_get();
+				if (t)
+					print_string("Loop detection enabled, timer ");
+				else
+					print_string("Loop detection disabled, timer ");
+				print_short(t); print_string(" ms\n");
 			}
 		} else if (cmd_compare(0, "pvid") && cmd_words_b[1] > 0 && cmd_words_b[2] > 0) {
 			__xdata uint16_t pvid;

--- a/dhcp.c
+++ b/dhcp.c
@@ -13,7 +13,9 @@
 #include "uip/uip.h"
 
 __xdata struct dhcp_state dhcp_state;
+__xdata struct dhcpd_state dhcpd_state;
 __xdata uip_ipaddr_t server;
+__xdata uip_ipaddr_t dhcpd_bcast;
 
 #define DHCP_HW_TYPE_ETH	1
 
@@ -353,7 +355,7 @@ void dhcp_stop(void) __banked
 }
 
 
-void dhcp_callback(void) __banked
+static void dhcpc_callback_inner(void)
 {
 	if (!dhcp_state.state)
 		return;
@@ -387,4 +389,339 @@ void dhcp_callback(void) __banked
 
 	// By default we do not send anything out
 	uip_len = 0;
+}
+
+
+/*
+ * Compare two 6 byte hardware addresses. Returns 0 when equal.
+ */
+static uint8_t mac_cmp(__xdata uint8_t *a, __xdata uint8_t *b)
+{
+	for (uint8_t i = 0; i < 6; i++)
+		if (a[i] != b[i])
+			return 1;
+	return 0;
+}
+
+
+/*
+ * Look up an existing lease for the given MAC address. Returns the
+ * pool index, or 0xff if no lease exists.
+ */
+static uint8_t dhcpd_find_lease(__xdata uint8_t *mac)
+{
+	for (uint8_t i = 0; i < dhcpd_state.pool_count; i++) {
+		if (dhcpd_state.leases[i].expires && !mac_cmp(dhcpd_state.leases[i].mac, mac))
+			return i;
+	}
+	return 0xff;
+}
+
+
+/*
+ * Allocate a new lease for the given MAC address. Prefers the first
+ * entry whose lease has expired. Returns the pool index or 0xff when
+ * the pool is full.
+ */
+static uint8_t dhcpd_alloc_lease(__xdata uint8_t *mac)
+{
+	for (uint8_t i = 0; i < dhcpd_state.pool_count; i++) {
+		if (!dhcpd_state.leases[i].expires) {
+			memcpy(dhcpd_state.leases[i].mac, mac, 6);
+			dhcpd_state.leases[i].expires = dhcpd_state.lease_time;
+			return i;
+		}
+	}
+	return 0xff;
+}
+
+
+/*
+ * Add an IPv4 option to the reply option buffer.
+ */
+static void dhcpd_addopt_ip(uint8_t code, __xdata uint8_t *ip)
+{
+	DHCP_OPT[dhcp_state.opt_ptr++] = code;
+	DHCP_OPT[dhcp_state.opt_ptr++] = 4;
+	DHCP_OPT[dhcp_state.opt_ptr++] = ip[0];
+	DHCP_OPT[dhcp_state.opt_ptr++] = ip[1];
+	DHCP_OPT[dhcp_state.opt_ptr++] = ip[2];
+	DHCP_OPT[dhcp_state.opt_ptr++] = ip[3];
+}
+
+
+/*
+ * Add a 32-bit option to the reply option buffer.
+ */
+static void dhcpd_addopt_u32(uint8_t code, uint32_t v)
+{
+	DHCP_OPT[dhcp_state.opt_ptr++] = code;
+	DHCP_OPT[dhcp_state.opt_ptr++] = 4;
+	DHCP_OPT[dhcp_state.opt_ptr++] = (v >> 24) & 0xff;
+	DHCP_OPT[dhcp_state.opt_ptr++] = (v >> 16) & 0xff;
+	DHCP_OPT[dhcp_state.opt_ptr++] = (v >> 8) & 0xff;
+	DHCP_OPT[dhcp_state.opt_ptr++] = v & 0xff;
+}
+
+
+/*
+ * Scan the options of an incoming DHCP packet and return the DHCP
+ * message type (DISCOVER, REQUEST, RELEASE, ...). Returns 0 if no
+ * message type option was found.
+ */
+static uint8_t dhcpd_parse_msg_type(void)
+{
+	uint16_t p = 0;
+	while (DHCP_OPT[p] != DHCP_END) {
+		uint8_t code = DHCP_OPT[p++];
+		if (!code) // PAD option has no length
+			continue;
+		uint8_t len = DHCP_OPT[p++];
+		if (code == DHCP_MESSAGE_TYPE && len == DHCP_MESSAGE_TYPE_LEN)
+			return DHCP_OPT[p];
+		p += len;
+		if (p > 300) // Safety limit for malformed packets
+			return 0;
+	}
+	return 0;
+}
+
+
+/*
+ * Build a BOOTP reply (OFFER or ACK) for the client that issued the
+ * current request. The chosen IP is taken from pool index idx.
+ */
+static void dhcpd_build_reply(uint8_t idx, uint8_t msg_type)
+{
+	// Preserve client MAC and transaction id before clearing the buffer
+	__xdata uint32_t req_tid = DHCP_P->tid;
+	__xdata uint8_t req_mac[6];
+	memcpy(req_mac, DHCP_P->client_addr, 6);
+
+	DHCP_P->type = 2; // BOOTREPLY
+	DHCP_P->hw = DHCP_HW_TYPE_ETH;
+	DHCP_P->hw_len = 6;
+	DHCP_P->hops = 0;
+	DHCP_P->tid = req_tid;
+	DHCP_P->delay = 0;
+	DHCP_P->flags = 0;
+	// Clear all fields from client_ip through the end of the bootp file area
+	memset(DHCP_P->client_ip, 0, 224);
+	// your_ip = offered address (same /24 as our own address)
+	DHCP_P->your_ip[0] = uip_hostaddr[0] & 0xff;
+	DHCP_P->your_ip[1] = uip_hostaddr[0] >> 8;
+	DHCP_P->your_ip[2] = uip_hostaddr[1] & 0xff;
+	DHCP_P->your_ip[3] = dhcpd_state.pool_first + idx;
+	memcpy(DHCP_P->client_addr, req_mac, 6);
+	DHCP_P->cookie[0] = 0x63;
+	DHCP_P->cookie[1] = 0x82;
+	DHCP_P->cookie[2] = 0x53;
+	DHCP_P->cookie[3] = 0x63;
+
+	dhcp_state.opt_ptr = 0;
+	DHCP_OPT[dhcp_state.opt_ptr++] = DHCP_MESSAGE_TYPE;
+	DHCP_OPT[dhcp_state.opt_ptr++] = DHCP_MESSAGE_TYPE_LEN;
+	DHCP_OPT[dhcp_state.opt_ptr++] = msg_type;
+
+	// Server identifier = our IP address
+	__xdata uint8_t our_ip[4];
+	our_ip[0] = uip_hostaddr[0] & 0xff;
+	our_ip[1] = uip_hostaddr[0] >> 8;
+	our_ip[2] = uip_hostaddr[1] & 0xff;
+	our_ip[3] = uip_hostaddr[1] >> 8;
+	dhcpd_addopt_ip(DHCP_SERVER_ID, our_ip);
+
+	// Subnet mask
+	__xdata uint8_t mask[4];
+	mask[0] = uip_netmask[0] & 0xff;
+	mask[1] = uip_netmask[0] >> 8;
+	mask[2] = uip_netmask[1] & 0xff;
+	mask[3] = uip_netmask[1] >> 8;
+	dhcpd_addopt_ip(DHCP_SUBNET_MASK, mask);
+
+	// Default router = our IP
+	dhcpd_addopt_ip(DHCP_ROUTER, our_ip);
+
+	// Lease time
+	dhcpd_addopt_u32(DHCP_LEASE, dhcpd_state.lease_time);
+
+	DHCP_OPT[dhcp_state.opt_ptr++] = DHCP_END;
+	// Pad reply to at least 300 bytes
+	while (dhcp_state.opt_ptr < 60) {
+		DHCP_OPT[dhcp_state.opt_ptr++] = 0;
+	}
+
+	uip_udp_send(sizeof(struct dhcp_pkt) + dhcp_state.opt_ptr);
+}
+
+
+/*
+ * DHCP server request handler. Inspects the inbound message type and
+ * either allocates a lease (OFFER) or confirms an existing one (ACK).
+ * RELEASE and DECLINE messages free the corresponding lease.
+ */
+static void dhcpd_handle_request(void)
+{
+	if (DHCP_P->type != 1) // Must be BOOTREQUEST
+		return;
+	if (DHCP_P->cookie[0] != 0x63 || DHCP_P->cookie[1] != 0x82 ||
+	    DHCP_P->cookie[2] != 0x53 || DHCP_P->cookie[3] != 0x63)
+		return;
+
+	__xdata uint8_t mac[6];
+	memcpy(mac, DHCP_P->client_addr, 6);
+
+	uint8_t msg_type = dhcpd_parse_msg_type();
+	print_string("dhcpd RX type "); print_byte(msg_type); write_char('\n');
+
+	switch (msg_type) {
+	case DHCP_MESSAGE_DISCOVER: {
+		uint8_t idx = dhcpd_find_lease(mac);
+		if (idx == 0xff)
+			idx = dhcpd_alloc_lease(mac);
+		if (idx == 0xff) {
+			print_string("dhcpd pool exhausted\n");
+			return;
+		}
+		print_string("dhcpd OFFER .");
+		print_byte(dhcpd_state.pool_first + idx); write_char('\n');
+		dhcpd_build_reply(idx, DHCP_MESSAGE_OFFER);
+		break;
+	}
+	case DHCP_MESSAGE_REQUEST: {
+		uint8_t idx = dhcpd_find_lease(mac);
+		if (idx == 0xff) {
+			// Unknown client: allocate fresh
+			idx = dhcpd_alloc_lease(mac);
+		}
+		if (idx == 0xff)
+			return;
+		dhcpd_state.leases[idx].expires = dhcpd_state.lease_time;
+		print_string("dhcpd ACK .");
+		print_byte(dhcpd_state.pool_first + idx); write_char('\n');
+		dhcpd_build_reply(idx, DHCP_MESSAGE_ACK);
+		break;
+	}
+	case 7: // DHCPRELEASE
+	case 4: { // DHCPDECLINE
+		uint8_t idx = dhcpd_find_lease(mac);
+		if (idx != 0xff)
+			dhcpd_state.leases[idx].expires = 0;
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+
+/*
+ * Age out DHCP server leases. Called once per second from the main
+ * idle loop when the DHCP server is running.
+ */
+void dhcpd_tick(void) __banked
+{
+	if (!dhcpd_state.enabled)
+		return;
+	for (uint8_t i = 0; i < dhcpd_state.pool_count; i++) {
+		if (dhcpd_state.leases[i].expires)
+			dhcpd_state.leases[i].expires--;
+	}
+}
+
+
+void dhcpd_start(void) __banked
+{
+	if (dhcpd_state.enabled) {
+		print_string("dhcpd already running\n");
+		return;
+	}
+	if (!dhcpd_state.pool_count) {
+		// Install a sensible default pool: .100-.107 on the same /24
+		dhcpd_state.pool_first = 100;
+		dhcpd_state.pool_count = 8;
+	}
+	if (!dhcpd_state.lease_time)
+		dhcpd_state.lease_time = 3600; // 1 hour
+
+	// Clear any leftover lease state
+	for (uint8_t i = 0; i < DHCPD_POOL_MAX; i++)
+		dhcpd_state.leases[i].expires = 0;
+
+	uip_ipaddr(dhcpd_bcast, 255, 255, 255, 255);
+	dhcpd_state.conn = uip_udp_new(&dhcpd_bcast, HTONS(DHCPC_CLIENT_PORT));
+	if (!dhcpd_state.conn) {
+		print_string("dhcpd failed to create UDP socket\n");
+		return;
+	}
+	uip_udp_bind(dhcpd_state.conn, HTONS(DHCPC_SERVER_PORT));
+	dhcpd_state.enabled = 1;
+	print_string("dhcpd enabled, pool .");
+	print_byte(dhcpd_state.pool_first); print_string(" +");
+	print_byte(dhcpd_state.pool_count); write_char('\n');
+}
+
+
+void dhcpd_stop(void) __banked
+{
+	if (!dhcpd_state.enabled)
+		return;
+	if (dhcpd_state.conn)
+		uip_udp_remove(dhcpd_state.conn);
+	dhcpd_state.conn = 0;
+	dhcpd_state.enabled = 0;
+	print_string("dhcpd stopped\n");
+}
+
+
+void dhcpd_set_pool(uint8_t first_octet, uint8_t count) __banked
+{
+	if (count > DHCPD_POOL_MAX)
+		count = DHCPD_POOL_MAX;
+	dhcpd_state.pool_first = first_octet;
+	dhcpd_state.pool_count = count;
+	for (uint8_t i = 0; i < DHCPD_POOL_MAX; i++)
+		dhcpd_state.leases[i].expires = 0;
+}
+
+
+void dhcpd_set_lease_time(uint32_t seconds) __banked
+{
+	dhcpd_state.lease_time = seconds;
+}
+
+
+uint8_t dhcpd_active_leases(void) __banked
+{
+	uint8_t n = 0;
+	for (uint8_t i = 0; i < dhcpd_state.pool_count; i++) {
+		if (dhcpd_state.leases[i].expires)
+			n++;
+	}
+	return n;
+}
+
+
+static void dhcpd_callback_inner(void)
+{
+	if (!dhcpd_state.enabled)
+		return;
+	if (uip_newdata()) {
+		dhcpd_handle_request();
+	} else {
+		// Make sure no stale data is sent out during periodic polls
+		uip_len = 0;
+	}
+}
+
+
+void dhcp_callback(void) __banked
+{
+	// Dispatch between DHCP client and DHCP server based on which
+	// uIP UDP connection invoked the callback.
+	if (dhcpd_state.enabled && uip_udp_conn == dhcpd_state.conn) {
+		dhcpd_callback_inner();
+		return;
+	}
+	dhcpc_callback_inner();
 }

--- a/dhcp.h
+++ b/dhcp.h
@@ -13,10 +13,21 @@
 #define DHCP_REQUEST_SENT	3
 #define DHCP_LEASING		4
 
+// Maximum number of leases handed out by the integrated DHCP server
+#define DHCPD_POOL_MAX		8
+
 void dhcp_start(void) __banked;
 void dhcp_stop(void) __banked;
 // void dhcp_periodic(void) __banked;
 void dhcp_callback(void) __banked;
+
+// Integrated DHCP server API
+void dhcpd_start(void) __banked;
+void dhcpd_stop(void) __banked;
+void dhcpd_set_pool(uint8_t first_octet, uint8_t count) __banked;
+void dhcpd_set_lease_time(uint32_t seconds) __banked;
+uint8_t dhcpd_active_leases(void) __banked;
+void dhcpd_tick(void) __banked;
 
 
 struct dhcp_state {
@@ -36,6 +47,20 @@ struct dhcp_state {
 	uint32_t renewal;
 
 	struct uip_udp_conn *conn;
+};
+
+struct dhcpd_lease {
+	uint8_t mac[6];
+	uint32_t expires;	// Seconds remaining on lease; 0 = free
+};
+
+struct dhcpd_state {
+	uint8_t enabled;
+	uint8_t pool_first;	// Last octet of first pool IP
+	uint8_t pool_count;	// Number of addresses in the pool (<= DHCPD_POOL_MAX)
+	uint32_t lease_time;	// Lease time in seconds
+	struct uip_udp_conn *conn;
+	struct dhcpd_lease leases[DHCPD_POOL_MAX];
 };
 
 typedef struct dhcp_state uip_udp_appstate_t;

--- a/html/system.html
+++ b/html/system.html
@@ -15,6 +15,7 @@
   <body>
     <div class="tab-bar">
       <button class="tab-btn active" onclick="openTab(event, 'system-tab')">System</button>
+      <button class="tab-btn" onclick="openTab(event, 'services-tab')">Services</button>
       <button class="tab-btn" onclick="openTab(event, 'advanced-tab')">Advanced</button>
     </div>
     <nav id="sidebar"></nav>
@@ -41,6 +42,60 @@
       <br/>
       Save all current settings to Flash:<br/>
       <input style="width:40%;" class="action" id="flash_sub" onclick="flashSave();" type="button" value="Save Settings to Flash">
+    </div>
+
+    <div id="services-tab" class="tab-content">
+      <h1>Services</h1>
+      <p>These services can be toggled here. Settings are applied immediately.
+        To persist them, use "Save Settings to Flash" on the System tab.</p>
+
+      <h2>Spanning Tree (STP)</h2>
+      <div class="row">
+        <div class="lcol"><label for="svc_stp">Enable STP:</label></div>
+        <div class="rcol"><input id="svc_stp" type="checkbox" onchange="svcToggleStp(this.checked);"/></div>
+      </div>
+
+      <h2>Loop Detection (RLDP)</h2>
+      <div class="row">
+        <div class="lcol"><label for="svc_lbd">Enable loop detection:</label></div>
+        <div class="rcol"><input id="svc_lbd" type="checkbox" onchange="svcToggleLbd(this.checked);"/></div>
+      </div>
+      <div class="row">
+        <div class="lcol"><label for="svc_lbd_timer">Detection interval (ms):</label></div>
+        <div class="rcol"><input id="svc_lbd_timer" type="number" min="10" max="65535" value="1000" size="6"/></div>
+      </div>
+
+      <h2>Management VLAN</h2>
+      <div class="row">
+        <div class="lcol"><label for="svc_mgmt_vlan">VLAN ID (0 = disabled):</label></div>
+        <div class="rcol"><input id="svc_mgmt_vlan" type="number" min="0" max="4094" value="0" size="6"/></div>
+      </div>
+      <div class="row">
+        <div class="lcol"></div>
+        <div class="rcol"><input class="action" type="button" value="Apply Management VLAN" onclick="svcApplyMgmtVlan();"/></div>
+      </div>
+
+      <h2>DHCP Server</h2>
+      <div class="row">
+        <div class="lcol"><label for="svc_dhcpd">Enable DHCP server:</label></div>
+        <div class="rcol"><input id="svc_dhcpd" type="checkbox" onchange="svcToggleDhcpd(this.checked);"/></div>
+      </div>
+      <div class="row">
+        <div class="lcol"><label for="svc_dhcpd_pool_start">Pool start (last octet):</label></div>
+        <div class="rcol"><input id="svc_dhcpd_pool_start" type="number" min="1" max="254" value="100" size="6"/></div>
+      </div>
+      <div class="row">
+        <div class="lcol"><label for="svc_dhcpd_pool_count">Pool size (max 8):</label></div>
+        <div class="rcol"><input id="svc_dhcpd_pool_count" type="number" min="1" max="8" value="8" size="6"/></div>
+      </div>
+      <div class="row">
+        <div class="lcol"><label for="svc_dhcpd_lease">Lease time (seconds):</label></div>
+        <div class="rcol"><input id="svc_dhcpd_lease" type="number" min="60" max="65535" value="3600" size="8"/></div>
+      </div>
+      <div class="row">
+        <div class="lcol">Active leases:</div>
+        <div class="rcol"><span id="svc_dhcpd_leases">0</span></div>
+      </div>
     </div>
 
     <div id="advanced-tab" class="tab-content">

--- a/html/system.js
+++ b/html/system.js
@@ -125,6 +125,67 @@ function resetSwitch() {
   }, 3000);
 }
 
+async function sendCmd(cmd) {
+  try {
+    const response = await fetch('/cmd', { method: 'POST', body: cmd });
+    console.log('cmd sent:', cmd, response);
+  } catch (err) {
+    console.error(`Error sending cmd '${cmd}':`, err);
+  }
+}
+
+function svcToggleStp(enabled) {
+  sendCmd(enabled ? 'stp on' : 'stp off').then(fetchServices);
+}
+
+function svcToggleLbd(enabled) {
+  if (enabled) {
+    const timer = document.getElementById('svc_lbd_timer').value || 1000;
+    sendCmd('lbd on ' + timer).then(fetchServices);
+  } else {
+    sendCmd('lbd off').then(fetchServices);
+  }
+}
+
+function svcApplyMgmtVlan() {
+  const vlan = parseInt(document.getElementById('svc_mgmt_vlan').value || '0', 10);
+  if (isNaN(vlan) || vlan < 0 || vlan > 4094) {
+    alert('Invalid VLAN ID');
+    return;
+  }
+  sendCmd('vlan ' + vlan + ' mgmt').then(fetchServices);
+}
+
+function svcToggleDhcpd(enabled) {
+  if (enabled) {
+    const start = parseInt(document.getElementById('svc_dhcpd_pool_start').value || '100', 10);
+    const count = parseInt(document.getElementById('svc_dhcpd_pool_count').value || '8', 10);
+    const lease = parseInt(document.getElementById('svc_dhcpd_lease').value || '3600', 10);
+    sendCmd('dhcpd on ' + start + ' ' + count + ' ' + lease).then(fetchServices);
+  } else {
+    sendCmd('dhcpd off').then(fetchServices);
+  }
+}
+
+function fetchServices() {
+  fetch('/services.json')
+    .then(r => r.json())
+    .then(s => {
+      document.getElementById('svc_stp').checked = !!s.stp;
+      document.getElementById('svc_lbd').checked = !!s.lbd;
+      if (s.lbd_timer) document.getElementById('svc_lbd_timer').value = s.lbd_timer;
+      document.getElementById('svc_mgmt_vlan').value = s.mgmt_vlan || 0;
+      document.getElementById('svc_dhcpd').checked = !!s.dhcpd;
+      if (s.dhcpd_pool_start) document.getElementById('svc_dhcpd_pool_start').value = s.dhcpd_pool_start;
+      if (s.dhcpd_pool_count) document.getElementById('svc_dhcpd_pool_count').value = s.dhcpd_pool_count;
+      if (s.dhcpd_lease_time) document.getElementById('svc_dhcpd_lease').value = s.dhcpd_lease_time;
+      document.getElementById('svc_dhcpd_leases').textContent = s.dhcpd_leases || 0;
+    })
+    .catch(err => console.error('Error fetching services:', err));
+}
+
 window.addEventListener("load", function() {
   systemInterval = setInterval(fetchIP, 1000);
+  fetchServices();
+  setInterval(fetchServices, 5000);
 });

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -600,6 +600,8 @@ void httpd_appcall(void)
 				send_mtu();
 			} else if (is_word(q, "/lag.json")) {
 				send_lag();
+			} else if (is_word(q, "/services.json")) {
+				send_services();
 			} else if (is_word(q, "/config")) {
 				send_config();
 			} else if (is_word(q, "/cmd_log")) {

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -13,6 +13,7 @@
 #include "version.h"
 #include "machine.h"
 #include "page_impl.h"
+#include "dhcp.h"
 
 // #define DEBUG
 #include "debug.h"
@@ -44,6 +45,11 @@ extern __xdata char sfp_module_vendor[2][17];
 extern __xdata char sfp_module_model[2][17];
 extern __xdata char sfp_module_serial[2][17];
 extern __xdata uint8_t sfp_options[2];
+
+extern __xdata uint8_t stpEnabled;
+extern __xdata uint16_t management_vlan;
+extern __xdata struct dhcp_state dhcp_state;
+extern __xdata struct dhcpd_state dhcpd_state;
 
 __code uint8_t * __code HTTP_RESPONCE_JSON = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n";
 __code uint8_t * __code HTTP_RESPONCE_TXT = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n";
@@ -796,6 +802,76 @@ found_end:
 	flash_read_bulk(outbuf + slen);
 	slen += valid_len;
 }
+
+/*
+ * Report the current state of on-device "services": spanning tree,
+ * loop detection, management VLAN, DHCP client and DHCP server.
+ * Returns a JSON object that the Services tab in the web UI reads
+ * to render checkboxes and status fields.
+ */
+void send_services(void)
+{
+	dbg_string("send_services called\n");
+	slen = strtox(outbuf, HTTP_RESPONCE_JSON);
+
+	slen += strtox(outbuf + slen, "{\"stp\":");
+	bool_to_html(stpEnabled);
+
+	slen += strtox(outbuf + slen, ",\"lbd\":");
+	__xdata uint16_t lbd_timer = port_rldp_get();
+	bool_to_html(lbd_timer != 0);
+	slen += strtox(outbuf + slen, ",\"lbd_timer\":");
+	{
+		__xdata uint16_t v = lbd_timer;
+		__xdata uint8_t d[5];
+		uint8_t n = 0;
+		if (!v) {
+			outbuf[slen++] = '0';
+		} else {
+			while (v) { d[n++] = '0' + (v % 10); v /= 10; }
+			while (n) outbuf[slen++] = d[--n];
+		}
+	}
+
+	slen += strtox(outbuf + slen, ",\"mgmt_vlan\":");
+	{
+		__xdata uint16_t v = management_vlan;
+		__xdata uint8_t d[5];
+		uint8_t n = 0;
+		if (!v) {
+			outbuf[slen++] = '0';
+		} else {
+			while (v) { d[n++] = '0' + (v % 10); v /= 10; }
+			while (n) outbuf[slen++] = d[--n];
+		}
+	}
+
+	slen += strtox(outbuf + slen, ",\"dhcp_client\":");
+	bool_to_html(dhcp_state.state == DHCP_LEASING);
+
+	slen += strtox(outbuf + slen, ",\"dhcpd\":");
+	bool_to_html(dhcpd_state.enabled);
+	slen += strtox(outbuf + slen, ",\"dhcpd_pool_start\":");
+	itoa_html(dhcpd_state.pool_first);
+	slen += strtox(outbuf + slen, ",\"dhcpd_pool_count\":");
+	itoa_html(dhcpd_state.pool_count);
+	slen += strtox(outbuf + slen, ",\"dhcpd_leases\":");
+	itoa_html(dhcpd_active_leases());
+	slen += strtox(outbuf + slen, ",\"dhcpd_lease_time\":");
+	{
+		__xdata uint32_t v = dhcpd_state.lease_time;
+		__xdata uint8_t d[10];
+		uint8_t n = 0;
+		if (!v) {
+			outbuf[slen++] = '0';
+		} else {
+			while (v) { d[n++] = '0' + (v % 10); v /= 10; }
+			while (n) outbuf[slen++] = d[--n];
+		}
+	}
+	char_to_html('}');
+}
+
 
 void send_cmd_log(void)
 {

--- a/httpd/page_impl.h
+++ b/httpd/page_impl.h
@@ -14,6 +14,7 @@ void send_mtu(void);
 void send_config(void);
 void send_cmd_log(void);
 void send_lag(void);
+void send_services(void);
 
 /*  Convert only the lower nibble to ascii HEX char.
     For convenience the upper nibble is masked out.

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -620,14 +620,41 @@ void port_eee_status_all(void) __banked
 }
 
 /*
- * Enable RLDP, Realtek's version of LLDP
+ * Enable RLDP, Realtek's Loop Detection Protocol. The device will
+ * periodically send a detection frame which, if it is received again
+ * on any of the configured ports, indicates a forwarding loop.
+ * The timer value p_ms controls the interval between detection frames
+ * in milliseconds.
  */
-void port_rldp_on(__xdata uint16_t p_ms)
+void port_rldp_on(__xdata uint16_t p_ms) __banked
 {
 	REG_WRITE(RTL8373_RLDP_TIMER, p_ms >> 8, p_ms, p_ms >> 8, p_ms);
 
+	// Do not trap reserved multicast addresses to the CPU so that RLDP
+	// detection packets can travel through the switch fabric.
 	REG_SET(RTL837X_RMA0_CONF, 0x00000000); // R4ecc
 	REG_SET(RTL837X_RMA_CONF, 0x00000000); // R4ecc
+}
+
+
+/*
+ * Disable RLDP by clearing the detection timer. The RMA configuration
+ * is restored so that reserved multicast addresses are trapped again.
+ */
+void port_rldp_off(void) __banked
+{
+	REG_SET(RTL8373_RLDP_TIMER, 0x00000000);
+}
+
+
+/*
+ * Returns the currently configured RLDP timer in milliseconds. A
+ * value of 0 indicates that loop detection is disabled.
+ */
+uint16_t port_rldp_get(void) __banked
+{
+	reg_read_m(RTL8373_RLDP_TIMER);
+	return ((uint16_t)sfr_data[2] << 8) | sfr_data[3];
 }
 
 

--- a/rtl837x_port.h
+++ b/rtl837x_port.h
@@ -61,4 +61,7 @@ void port_eee_status(uint8_t port) __banked;
 void print_port_ingress_filter_mode(vlan_ingress_mode_t mode) __banked;
 bool port_ingress_vlan_filter_set(__xdata uint8_t port, __xdata bool enabled) __banked;
 bool port_ingress_vlan_filter_get(__xdata uint8_t port) __banked;
+void port_rldp_on(__xdata uint16_t p_ms) __banked;
+void port_rldp_off(void) __banked;
+uint16_t port_rldp_get(void) __banked;
 #endif

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -87,6 +87,7 @@ volatile __xdata uint8_t sec_counter;
 volatile __xdata uint16_t sleep_ticks;
 __xdata uint8_t stp_clock;
 extern __xdata struct dhcp_state dhcp_state;
+extern __xdata struct dhcpd_state dhcpd_state;
 
 #define STP_TICK_DIVIDER 3
 
@@ -1252,6 +1253,9 @@ void idle(void)
 		// Check for button presses once a second
 		handle_button();
 
+		// Age out DHCP server leases once per second
+		dhcpd_tick();
+
 #ifdef DEBUG
 		print_sfr_data();
 		write_char('\n');
@@ -2169,6 +2173,13 @@ void main(void)
 	print_reg(RTL837X_REG_SEC_COUNTER);
 #endif
 	stpEnabled = 0;
+	// Loop detection (RLDP) starts disabled
+	port_rldp_off();
+	// DHCP server starts disabled; enable via CLI command or config
+	dhcpd_state.enabled = 0;
+	dhcpd_state.pool_count = 0;
+	dhcpd_state.lease_time = 0;
+	dhcpd_state.conn = 0;
 	nic_setup();
 	vlan_setup();
 	port_l2_setup();

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -919,7 +919,9 @@ uip_process(u8_t flag) __banked
     
     /* Check if we have a DHCP packet, otherwise check if the packet is destined for our IP address. */
 #if !UIP_CONF_IPV6
-    if(!(BUF->proto == UIP_PROTO_UDP && UDPBUF->destport == HTONS(DHCPC_CLIENT_PORT))) {
+    if(!(BUF->proto == UIP_PROTO_UDP &&
+         (UDPBUF->destport == HTONS(DHCPC_CLIENT_PORT) ||
+          UDPBUF->destport == HTONS(DHCPC_SERVER_PORT)))) {
       if(!uip_ipaddr_cmpx(BUF->destipaddr, uip_hostaddr)) {
         UIP_STAT(++uip_stat.ip.drop);
         goto drop;


### PR DESCRIPTION
The README lists STP, the proprietary loop prevention protocols and a DHCP server as the remaining missing features. This change makes those features user-accessible:

- Add CLI and web controls for the existing STP and management VLAN implementations via a new Services tab in the system page.
- Expose Realtek's loop detection protocol (RLDP) through a new `lbd` CLI command and a web toggle with a configurable probe interval.
- Add a minimal integrated DHCP server (single subnet, up to 8 leases) with CLI (`dhcpd on/off`) and web configuration. The server shares the existing UDP callback with the DHCP client, dispatching based on which uIP connection fires. uIP's IPv4 input is extended to accept broadcast UDP destined for port 67 so client DISCOVER/REQUEST frames can reach the server.
- Add a `/services.json` endpoint reporting the current state of STP, RLDP, management VLAN, DHCP client and DHCP server for the new Services tab.
- Update README to match the now-supported feature set.