### PR TITLE
Port names

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -43,6 +43,9 @@ extern __xdata struct dhcp_state dhcp_state;
 
 __xdata uint8_t vlan_names[VLAN_NAMES_SIZE];
 __xdata uint16_t vlan_ptr;
+
+__xdata char port_names[9][PORT_NAME_SIZE];
+
 extern __xdata uint16_t management_vlan;
 __xdata uint8_t gpio_last_value[8] = { 0 };
 
@@ -514,20 +517,47 @@ void parse_mirror(void)
 
 void parse_port(void)
 {
-	print_string("\nPORT ");
+	if (cmd_words_b[3] <= 0) {
+		print_string("\nUsage:");
+		print_string("\nport <port> [show|on|off]");
+		print_string("\nport <port> [10m|100m|1g|2g5|duplex] [half|full]");
+		print_string("\nport <port> name [custom port name]\n");
+		return;
+	}
+
+	if (cmd_buffer[cmd_words_b[1]] < '1' || cmd_buffer[cmd_words_b[1]] > '9' || cmd_buffer[cmd_words_b[1] + 1] != ' ' ) {
+		print_string("Illegal port number\n");
+		return;
+	}
 	phy_settings.port = cmd_buffer[cmd_words_b[1]] - '1';
 	phy_settings.port = machine.phys_to_log_port[phy_settings.port];
-	print_byte(phy_settings.port);
-	if (machine.is_sfp[phy_settings.port]) {
-		print_string(" is SFP no PHY information available.\n");
+	if (phy_settings.port > machine.max_port || phy_settings.port < machine.min_port) {
+		print_string("This machine has no port with the specified number\n");
 		return;
 	}
-	if (cmd_words_b[2] <= 0) {
-		print_string("\nport <port> [show|on|off|10m|100m|1g|2g5] [half|full]");
-		return;
-	}
+
+	print_string("Logical Port: "); print_byte(phy_settings.port); write_char('\n');
 	phy_settings.duplex = PHY_DUPLEX_BOTH;
-	if (cmd_compare(2, "10m")) {
+
+	if (cmd_compare(2, "show")) {
+		print_string("Name: ");
+		print_string_x(port_names[phy_settings.port]);
+		if (!machine.is_sfp[phy_settings.port]) {
+			phy_show(phy_settings.port);
+		}
+	} else if (cmd_compare(2, "name")) {
+		uint8_t i = 0;
+		while ( (i < PORT_NAME_SIZE-1) && (cmd_buffer[cmd_words_b[3] + i] != '\0') ) {
+			port_names[phy_settings.port][i] = cmd_buffer[cmd_words_b[3] + i];
+			i++;
+		}
+		port_names[phy_settings.port][i] = '\0';
+		print_string("\nName set to: \"");
+		print_string_x(port_names[phy_settings.port]);
+		print_string("\"\n");
+	} else if (machine.is_sfp[phy_settings.port]) {
+		print_string(" is SFP no PHY information available.\n");
+	} else if (cmd_compare(2, "10m")) {
 		print_string(" 10M\n");
 		phy_settings.speed = PHY_SPEED_10M;
 		if (cmd_compare(3, "half"))
@@ -570,9 +600,8 @@ void parse_port(void)
 		else
 			phy_settings.speed = PHY_DUPLEX_HALF;
 		phy_set_duplex();
-	}
-	if (cmd_compare(2, "show")) {
-		phy_show(phy_settings.port);
+	} else {
+		print_string("Unknown port command\n");
 	}
 }
 

--- a/cmd_parser.h
+++ b/cmd_parser.h
@@ -7,6 +7,7 @@
 
 extern __xdata uint8_t cmd_buffer[CMD_BUF_SIZE];
 extern __xdata uint8_t cmd_available;
+extern __xdata char port_names[9][PORT_NAME_SIZE];
 
 uint8_t cmd_tokenize(void) __banked;
 void cmd_parser(void) __banked;

--- a/cmd_parser.h
+++ b/cmd_parser.h
@@ -7,7 +7,6 @@
 
 extern __xdata uint8_t cmd_buffer[CMD_BUF_SIZE];
 extern __xdata uint8_t cmd_available;
-extern __xdata char port_names[9][PORT_NAME_SIZE];
 
 uint8_t cmd_tokenize(void) __banked;
 void cmd_parser(void) __banked;

--- a/html/main.js
+++ b/html/main.js
@@ -9,6 +9,7 @@ var pAdvertised = new Int8Array(10);
 var numPorts = 0;
 var logToPhysPort = new Int8Array(10);
 var physToLogPort = new Int8Array(10);
+var portNames = new Array(10);
 var currentRequests = [];
 var currentCallback;
 function drawPorts() {
@@ -136,6 +137,7 @@ function update(callback) {
 	let n = p.portNum;
 	logToPhysPort[p.logPort] = n;
 	physToLogPort[n-1] = p.logPort;
+	portNames[p.logPort] = p.name;
 	let pid = "port" + n;
 	let ttid = "tt_" + n;
 	n--;
@@ -148,12 +150,17 @@ function update(callback) {
 	var leds = psvg.contentDocument.getElementsByClassName("led");
         if (leds[0] == null || leds[0].style == null)
           continue;
+	const portName = p.name || portNames[p.logPort] || '';
+	var iHTML = "<table border=\"0\" class=\"tt_table\">";
+	iHTML += "<tr><td align=\"left\">Name</td><td>:</td><td>" + portName + "</td></tr>";
 	if (p.enabled == 0) {
 	  pState[n] = -1;
 	  bgs[0].style.fill = "red";
 	  leds[0].style.fill = "black"; leds[1].style.fill = "black";
 	  psvg.style.opacity = 0.4;
-	  tt.innerHTML = "Not enabled.";
+	  iHTML += "<tr><td align=\"left\">Status</td><td>:</td><td>Not enabled.</td></tr>";
+	  iHTML += "</table>";
+	  tt.innerHTML = iHTML;
 	} else {
 	  psvg.style.opacity = 1.0;
 	  pState[n] = p.link;
@@ -165,7 +172,6 @@ function update(callback) {
 	    leds[0].style.fill = "black"; leds[1].style.fill = "black";
 	    psvg.style.opacity = 0.4
 	  }
-	  var iHTML = "<table border=\"0\" class=\"tt_table\">";
 	  iHTML += "<tr><td align=\"left\">Link speed</td><td>:</td><td>" + linkS[p.link + 1] + "</td></tr>";
 	  if (p.isSFP) {
 	    pAdvertised[n] = 0;

--- a/html/main.js
+++ b/html/main.js
@@ -152,7 +152,7 @@ function update(callback) {
           continue;
 	const portName = p.name || portNames[p.logPort] || '';
 	var iHTML = "<table border=\"0\" class=\"tt_table\">";
-	iHTML += "<tr><td align=\"left\">Name</td><td>:</td><td>" + portName + "</td></tr>";
+	if (portName) iHTML += "<tr><td align=\"left\">Name</td><td>:</td><td>" + portName + "</td></tr>";
 	if (p.enabled == 0) {
 	  pState[n] = -1;
 	  bgs[0].style.fill = "red";

--- a/html/ports.html
+++ b/html/ports.html
@@ -11,7 +11,7 @@
     <h1>Port Configuration</h1>
     <form id="vform" action="/vlan.html">
     <table id="speedtable">
-      <tr> <th>Port</th> <th>Current Link Speed</th><th>Set Speed</th><th>Disabled</th><th>Apply</th></tr>
+      <tr> <th>Port</th> <th>Name</th> <th>Current Link Speed</th><th>Set Speed</th><th>Disabled</th><th>Apply</th></tr>
     </table>
     <h2 style="margin-top:3em">Configure Maximum Frame Size (MTU) forwarded at Port</h2>
     <table id="mtutable" style="margin-top:1em">

--- a/html/ports.js
+++ b/html/ports.js
@@ -19,6 +19,8 @@ function createPortTable() {
       console.log("Table row: " + i + "pState: " + pState[i-2]);
       const tr = tbl.insertRow();
       let td = tr.insertCell(); td.appendChild(document.createTextNode(`Port ${i}`));
+      let portName = portNames[physToLogPort[i-1]] || '';
+      td = tr.insertCell(); td.appendChild(document.createTextNode(portName));
       td = tr.insertCell(); td.innerHTML = linkS[pState[i] + 1];
       td = tr.insertCell(); td.innerHTML = sSelect.replaceAll("speed_sel", "speed_sel_" + i);
       td = tr.insertCell(); td.innerHTML = dSwitch.replaceAll("disable_port", "disable_port_" + i)
@@ -66,7 +68,7 @@ function updatePortTable() {
   for (let i = 1; i <= numPorts ; i++) {
     if (pIsSFP[i-1])
       continue;
-    tbl.rows[i].cells[1].innerHTML = `${linkS[pState[i-1]+1]}`;
+    tbl.rows[i].cells[2].innerHTML = `${linkS[pState[i-1]+1]}`;
     if (!clicked[i] && pState[i - 1] < 0) {
       document.getElementById('speed_sel_' + i).disabled = true;
       document.getElementById('disable_port_' + i).checked = true;

--- a/html/stat.html
+++ b/html/stat.html
@@ -38,7 +38,7 @@
     </div>
     <h1>Port Statistics</h1>
     <table id="statstable">
-      <tr> <th>Port</th> <th>link</th> <th>TX Good</th> <th>TX Bad</th> <th>RX Good</th> <th>RX Bad</th> <th> All Counters </th></tr>
+      <tr> <th>Port</th> <th>Name</th> <th>link</th> <th>TX Good</th> <th>TX Bad</th> <th>RX Good</th> <th>RX Bad</th> <th> All Counters </th></tr>
       <script src="/stat.js"></script>
     </table>
     </div>

--- a/html/stat.js
+++ b/html/stat.js
@@ -162,17 +162,19 @@ function fillStats() {
   if (tbl.rows.length > 1) {
     for (let i = 0; i < numPorts; i++) {
       console.log("Table Update row: " + i + " state " + pState[i] + " is " + linkS[pState[i] +1]);
-      tbl.rows[i+1].cells[1].innerHTML = `${linkS[pState[i]+1]}`;
-      tbl.rows[i+1].cells[2].innerHTML = `${txG[i]} pkts`;
-      tbl.rows[i+1].cells[3].innerHTML = `${txB[i]} pkts`;
-      tbl.rows[i+1].cells[4].innerHTML = `${rxG[i]} pkts`;
-      tbl.rows[i+1].cells[5].innerHTML = `${rxB[i]} pkts`;
+      tbl.rows[i+1].cells[2].innerHTML = `${linkS[pState[i]+1]}`;
+      tbl.rows[i+1].cells[3].innerHTML = `${txG[i]} pkts`;
+      tbl.rows[i+1].cells[4].innerHTML = `${txB[i]} pkts`;
+      tbl.rows[i+1].cells[5].innerHTML = `${rxG[i]} pkts`;
+      tbl.rows[i+1].cells[6].innerHTML = `${rxB[i]} pkts`;
     }
   } else {
     for (let i = 0; i < numPorts; i++) {
       console.log("Table row: " + i);
       const tr = tbl.insertRow();
       let td = tr.insertCell(); td.appendChild(document.createTextNode(`Port ${i+1}`));
+      let portName = portNames[physToLogPort[i]] || '';
+      td = tr.insertCell(); td.appendChild(document.createTextNode(portName));
       td = tr.insertCell(); td.appendChild(document.createTextNode(`${linkS[pState[i]+1]}`));
       td = tr.insertCell(); td.appendChild(document.createTextNode(`${txG[i]} pkts`));
       td = tr.insertCell();td.appendChild(document.createTextNode(`${txB[i]} pkts`));

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -13,6 +13,7 @@
 #include "version.h"
 #include "machine.h"
 #include "page_impl.h"
+#include "cmd_parser.h"
 
 // #define DEBUG
 #include "debug.h"
@@ -633,6 +634,11 @@ void send_status(void)
 		itoa_html(machine.log_to_phys_port[i]);
 		slen += strtox(outbuf + slen, ",\"logPort\":");
 		itoa_html(i);
+		slen += strtox(outbuf + slen, ",\"name\":\"");
+		for (uint8_t j = 0; j < PORT_NAME_SIZE && port_names[i][j]; j++) {
+			char_to_html(port_names[i][j]);
+		}
+		slen += strtox(outbuf + slen, "\"");
 
 		if (machine.is_sfp[i]) {
 			slen += strtox(outbuf + slen, ",\"isSFP\":1,\"enabled\":");

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -13,7 +13,6 @@
 #include "version.h"
 #include "machine.h"
 #include "page_impl.h"
-#include "cmd_parser.h"
 
 // #define DEBUG
 #include "debug.h"

--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -98,6 +98,8 @@ struct flash_region_t {
     uint16_t len;
 };
 
+extern __xdata char port_names[9][PORT_NAME_SIZE];
+
 extern __xdata uint8_t uip_buf[UIP_CONF_BUFFER_SIZE+2];
 extern __xdata struct uip_eth_addr uip_ethaddr;
 

--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -36,6 +36,9 @@ extern __xdata uint8_t sbuf[SBUF_SIZE];
 // Size of the TCP Output buffer
 #define TCP_OUTBUF_SIZE 2500
 
+// Size of the port name, including the terminating null byte
+#define PORT_NAME_SIZE 32
+
 // Size of the memory area dedicated to VLAN-names
 #define VLAN_NAMES_SIZE 1024
 

--- a/rtl837x_phy.c
+++ b/rtl837x_phy.c
@@ -367,12 +367,15 @@ void phy_show(uint8_t port) __banked
 		print_string("5G");
 		break;
 	default:
-		print_string("10M");
+		print_string("Down");
 	}
-	if (v & 0x8)
-		print_string(" full duplex");
-	else
-		print_string(" half duplex");
+
+	if ( (((v & 0x0600) >> 7) | ((v & 0x0030) >> 4)) <= 6) { // Link is up
+		if (v & 0x8)
+			print_string(" full duplex");
+		else
+			print_string(" half duplex");
+	}
 
 	phy_read(port,  PHY_MMD_AN, PHY_ANEG_CTRL);
 	v = SFR_DATA_U16;

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1974,7 +1974,7 @@ void check_and_flash_update_image(void)
 		__xdata uint16_t i = 0;
 		__xdata uint16_t j = 0;
 		__xdata uint8_t * __xdata bptr;
-		print_string("found update image! Checking integrity");
+		print_string("found update image!\nChecking integrity");
 		flash_init(0); // Re-initialize flash for non-DIO operation, otherwise flashing will fail
 		set_sys_led_state(SYS_LED_FAST);
 		crc_value = 0x0000;


### PR DESCRIPTION
This implements #171 

The port command has been extended, now also assigning a name is possible:
```
> port 1 name Desktop Computer
Logical Port: 04

Name set to: "Desktop Computer"
```
Removing an assigned name is done leaving the name empty:
```
> port 1 name
Logical Port: 04

Name set to: ""
```

html/.js has been implemented entirely by MS Copilot - no warranties ;-)

<img width="1419" height="457" alt="grafik" src="https://github.com/user-attachments/assets/de35482c-75d5-4c4e-99e3-750af615369b" />
