### PR TITLE
Remove `__gptrput()` and `__gptrget()` calls

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -169,7 +169,7 @@ uint8_t atoi_hex(uint8_t idx)
 }
 
 
-uint8_t atoi_byte(uint8_t __xdata *out, uint8_t idx)
+uint8_t atoi_byte(__xdata uint8_t *out, uint8_t idx)
 {
 	uint8_t err = 1;
 	uint8_t num = 0;
@@ -185,7 +185,7 @@ uint8_t atoi_byte(uint8_t __xdata *out, uint8_t idx)
 }
 
 
-uint8_t atoi_short(uint16_t __xdata *vlan, uint8_t idx)
+uint8_t atoi_short(__xdata uint16_t *vlan, uint8_t idx)
 {
 	uint8_t err = 1;
 
@@ -200,7 +200,7 @@ uint8_t atoi_short(uint16_t __xdata *vlan, uint8_t idx)
 }
 
 
-uint8_t parse_ip(register uint8_t idx)
+uint8_t parse_ip(uint8_t idx)
 {
 	__xdata uint8_t b;
 

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -447,7 +447,7 @@ err:
 }
 
 
-bool vlan_ingress_mode_parse(char c, vlan_ingress_mode_t *mode)
+bool vlan_ingress_mode_parse(char c, __xdata vlan_ingress_mode_t *mode)
 {
 	switch (c) {
 	case 'u':

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -169,30 +169,33 @@ uint8_t atoi_hex(uint8_t idx)
 }
 
 
-uint8_t atoi_byte(register uint8_t *out, register uint8_t idx)
+uint8_t atoi_byte(uint8_t __xdata *out, uint8_t idx)
 {
-	__xdata uint8_t err = 1;
-	*out = 0;
+	uint8_t err = 1;
+	uint8_t num = 0;
 
 	while (isnumber(cmd_buffer[idx])) {
 		err = 0;
-		*out = (*out * 10) + cmd_buffer[idx] - '0';
+		num = (num * 10) + cmd_buffer[idx] - '0';
 		idx++;
 	}
+
+	*out = num;
 	return err;
 }
 
 
-uint8_t atoi_short(register uint16_t *vlan, register uint8_t idx)
+uint8_t atoi_short(uint16_t __xdata *vlan, uint8_t idx)
 {
-	__xdata uint8_t err = 1;
-	*vlan = 0;
+	uint8_t err = 1;
 
 	while (isnumber(cmd_buffer[idx])) {
 		err = 0;
-		*vlan = (*vlan * 10) + cmd_buffer[idx] - '0';
+		uint8_t val = cmd_buffer[idx] - '0';
+		*vlan = (*vlan * 10) + val;
 		idx++;
 	}
+
 	return err;
 }
 

--- a/dhcp.c
+++ b/dhcp.c
@@ -216,7 +216,7 @@ void dhcp_send_request(void)
 }
 
 
-void ip_opt(uint8_t * __xdata ip)
+void ip_opt(__xdata uint8_t * ip)
 {
 	dhcp_state.opt_ptr++;
 	uint8_t len = DHCP_OPT[dhcp_state.opt_ptr++];

--- a/dhcp.c
+++ b/dhcp.c
@@ -82,7 +82,7 @@ struct dhcp_pkt {
 __xdata uint32_t long_value;
 
 
-void dhcp_print_ip(uint8_t *a)
+void dhcp_print_ip(__xdata uint8_t *a)
 {
 	itoa(a[0]); write_char('.');
 	itoa(a[1]); write_char('.');

--- a/dhcp.h
+++ b/dhcp.h
@@ -35,7 +35,7 @@ struct dhcp_state {
 	uint32_t rebind;
 	uint32_t renewal;
 
-	struct uip_udp_conn *conn;
+	__xdata struct uip_udp_conn *conn;
 };
 
 typedef struct dhcp_state uip_udp_appstate_t;

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -97,7 +97,7 @@ void itoa_html(uint8_t v)
 	char_to_html('0' + (v % 10));
 }
 
-void string_to_html(register char *s)
+void string_to_html(__code char *s)
 {
 	while (*s) char_to_html(*s++);
 }

--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -148,7 +148,7 @@ uint16_t strcpy(register __xdata uint8_t *dst, register const char *s);
 void tcpip_output(void);
 uint8_t read_flash(uint8_t bank, __code uint8_t *addr);
 void get_random_32(void);
-void read_reg_timer(uint32_t * tmr);
+void read_reg_timer(__xdata uint32_t * tmr);
 void sfp_print_info(uint8_t sfp);
 bool gpio_pin_test(uint8_t pin);
 void set_sys_led_state(uint8_t state);

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -688,7 +688,7 @@ void cpy_4(__xdata uint8_t dest[], __xdata uint8_t source[])
 }
 
 
-void read_reg_timer(uint32_t * tmr)
+void read_reg_timer(__xdata uint32_t * tmr)
 {
 	uint8_t * val = (uint8_t *)tmr;
 	SFR_REG_ADDR_U16 = RTL837X_REG_SEC_COUNTER;

--- a/uip/timer.c
+++ b/uip/timer.c
@@ -64,7 +64,7 @@
  *
  */
 void
-timer_set(struct timer *t, clock_time_t interval)
+timer_set(__xdata struct timer *t, clock_time_t interval)
 {
   t->interval = interval;
   t->start = clock_time();
@@ -84,7 +84,7 @@ timer_set(struct timer *t, clock_time_t interval)
  * \sa timer_restart()
  */
 void
-timer_reset(struct timer *t)
+timer_reset(__xdata struct timer *t)
 {
   t->start += t->interval;
 }
@@ -104,7 +104,7 @@ timer_reset(struct timer *t)
  * \sa timer_reset()
  */
 void
-timer_restart(struct timer *t)
+timer_restart(__xdata struct timer *t)
 {
   t->start = clock_time();
 }
@@ -121,7 +121,7 @@ timer_restart(struct timer *t)
  *
  */
 int
-timer_expired(struct timer *t)
+timer_expired(__xdata struct timer *t)
 {
   return (clock_time_t)(clock_time() - t->start) >= (clock_time_t)t->interval;
 }

--- a/uip/timer.h
+++ b/uip/timer.h
@@ -76,10 +76,10 @@ struct timer {
   clock_time_t interval;
 };
 
-void timer_set(struct timer *t, clock_time_t interval);
-void timer_reset(struct timer *t);
-void timer_restart(struct timer *t);
-int timer_expired(struct timer *t);
+void timer_set(__xdata struct timer *t, clock_time_t interval);
+void timer_reset(__xdata struct timer *t);
+void timer_restart(__xdata struct timer *t);
+int timer_expired(__xdata struct timer *t);
 
 #endif /* __TIMER_H__ */
 

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -465,7 +465,7 @@ uip_connect(register __xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banke
 #endif /* UIP_ACTIVE_OPEN */
 /*---------------------------------------------------------------------------*/
 #if UIP_UDP
-struct uip_udp_conn *
+__xdata struct uip_udp_conn *
 uip_udp_new(uip_ipaddr_t *ripaddr, u16_t rport) __banked
 {
   __xdata struct uip_udp_conn *conn;

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -241,7 +241,7 @@ __xdata struct uip_stats uip_stat;
 
 #if ! UIP_ARCH_ADD32
 void
-uip_add32(u8_t *op32, u16_t op16)
+uip_add32(u8_t __xdata * op32, u16_t op16)
 {
   uip_acc32[3] = op32[3] + (op16 & 0xff);
   uip_acc32[2] = op32[2] + (op16 >> 8);

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -466,7 +466,7 @@ uip_connect(register __xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banke
 /*---------------------------------------------------------------------------*/
 #if UIP_UDP
 __xdata struct uip_udp_conn *
-uip_udp_new(uip_ipaddr_t *ripaddr, u16_t rport) __banked
+uip_udp_new(__xdata uip_ipaddr_t *ripaddr, u16_t rport) __banked
 {
   __xdata struct uip_udp_conn *conn;
   

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -466,7 +466,7 @@ uip_connect(register __xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banke
 /*---------------------------------------------------------------------------*/
 #if UIP_UDP
 __xdata struct uip_udp_conn *
-uip_udp_new(__xdata uip_ipaddr_t *ripaddr, u16_t rport) __banked
+uip_udp_new(__xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banked
 {
   __xdata struct uip_udp_conn *conn;
   
@@ -1901,7 +1901,7 @@ htons(u16_t val)
 }
 /*---------------------------------------------------------------------------*/
 void
-uip_send(register __xdata const void *data, register uint16_t len) __banked
+uip_send(__xdata const void *data, __xdata uint16_t len) __banked
 {
   if(len > 0) {
     uip_slen = len;

--- a/uip/uip.h
+++ b/uip/uip.h
@@ -495,7 +495,7 @@ void uip_unlisten(u16_t port) __banked;
  * or NULL if no connection could be allocated.
  *
  */
-__xdata struct uip_conn *uip_connect(register __xdata uip_ipaddr_t *ripaddr, __xdata u16_t port) __banked;
+__xdata struct uip_conn *uip_connect(__xdata uip_ipaddr_t *ripaddr, __xdata u16_t port) __banked;
 
 
 
@@ -535,7 +535,7 @@ __xdata struct uip_conn *uip_connect(register __xdata uip_ipaddr_t *ripaddr, __x
  *
  * \hideinitializer
  */
-void uip_send(register __xdata const void *data, register uint16_t len) __banked;
+void uip_send(__xdata const void *data, __xdata uint16_t len) __banked;
 
 /**
  * The length of any incoming data that is currently avaliable (if avaliable)
@@ -763,7 +763,7 @@ void uip_send(register __xdata const void *data, register uint16_t len) __banked
  * \return The uip_udp_conn structure for the new connection or NULL
  * if no connection could be allocated.
  */
-__xdata struct uip_udp_conn *uip_udp_new(__xdata uip_ipaddr_t *ripaddr, u16_t rport) __banked;
+__xdata struct uip_udp_conn *uip_udp_new(__xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banked;
 
 /**
  * Removed a UDP connection.
@@ -880,8 +880,8 @@ __xdata struct uip_udp_conn *uip_udp_new(__xdata uip_ipaddr_t *ripaddr, u16_t rp
  */
 #if !UIP_CONF_IPV6
 #define uip_ipaddr_copy(dest, src) do { \
-                     ((u16_t __xdata *)dest)[0] = ((u16_t __xdata *)src)[0]; \
-                     ((u16_t __xdata *)dest)[1] = ((u16_t __xdata *)src)[1]; \
+                     ((__xdata u16_t *)dest)[0] = ((__xdata u16_t *)src)[0]; \
+                     ((__xdata u16_t *)dest)[1] = ((__xdata u16_t *)src)[1]; \
                   } while(0)
 #else /* !UIP_CONF_IPV6 */
 #define uip_ipaddr_copy(dest, src) memcpy(dest, src, sizeof(uip_ip6addr_t))
@@ -908,8 +908,8 @@ __xdata struct uip_udp_conn *uip_udp_new(__xdata uip_ipaddr_t *ripaddr, u16_t rp
  * \hideinitializer
  */
 #if !UIP_CONF_IPV6
-#define uip_ipaddr_cmp(addr1, addr2) (((__xdata u16_t *)addr1)[0] == ((u16_t *)addr2)[0] && \
-				      ((__xdata u16_t *)addr1)[1] == ((u16_t *)addr2)[1])
+#define uip_ipaddr_cmp(addr1, addr2) (((__xdata u16_t *)addr1)[0] == ((__xdata u16_t *)addr2)[0] && \
+				      ((__xdata u16_t *)addr1)[1] == ((__xdata u16_t *)addr2)[1])
 #define uip_ipaddr_cmpx(addr1, addr2) (((__xdata u16_t *)addr1)[0] == ((__xdata u16_t *)addr2)[0] && \
 				      ((__xdata u16_t *)addr1)[1] == ((__xdata u16_t *)addr2)[1])
 #define uip_ipaddr_cmpc(addr1, addr2) (((__xdata u16_t *)addr1)[0] == ((__code u16_t *)addr2)[0] && \

--- a/uip/uip.h
+++ b/uip/uip.h
@@ -763,7 +763,7 @@ void uip_send(register __xdata const void *data, register uint16_t len) __banked
  * \return The uip_udp_conn structure for the new connection or NULL
  * if no connection could be allocated.
  */
-__xdata struct uip_udp_conn *uip_udp_new(uip_ipaddr_t *ripaddr, u16_t rport) __banked;
+__xdata struct uip_udp_conn *uip_udp_new(__xdata uip_ipaddr_t *ripaddr, u16_t rport) __banked;
 
 /**
  * Removed a UDP connection.

--- a/uip/uip.h
+++ b/uip/uip.h
@@ -763,7 +763,7 @@ void uip_send(register __xdata const void *data, register uint16_t len) __banked
  * \return The uip_udp_conn structure for the new connection or NULL
  * if no connection could be allocated.
  */
-struct uip_udp_conn *uip_udp_new(uip_ipaddr_t *ripaddr, u16_t rport) __banked;
+__xdata struct uip_udp_conn *uip_udp_new(uip_ipaddr_t *ripaddr, u16_t rport) __banked;
 
 /**
  * Removed a UDP connection.

--- a/uip/uip.h
+++ b/uip/uip.h
@@ -880,8 +880,8 @@ struct uip_udp_conn *uip_udp_new(uip_ipaddr_t *ripaddr, u16_t rport) __banked;
  */
 #if !UIP_CONF_IPV6
 #define uip_ipaddr_copy(dest, src) do { \
-                     ((u16_t *)dest)[0] = ((u16_t *)src)[0]; \
-                     ((u16_t *)dest)[1] = ((u16_t *)src)[1]; \
+                     ((u16_t __xdata *)dest)[0] = ((u16_t __xdata *)src)[0]; \
+                     ((u16_t __xdata *)dest)[1] = ((u16_t __xdata *)src)[1]; \
                   } while(0)
 #else /* !UIP_CONF_IPV6 */
 #define uip_ipaddr_copy(dest, src) memcpy(dest, src, sizeof(uip_ip6addr_t))

--- a/uip/uip_arch.h
+++ b/uip/uip_arch.h
@@ -81,7 +81,7 @@
  *
  * \param op16 A 16-bit integer in host byte order.
  */
-void uip_add32(u8_t *op32, u16_t op16);
+void uip_add32(u8_t __xdata * op32, u16_t op16);
 
 /**
  * Calculate the Internet checksum over a buffer.

--- a/uip/uip_arch.h
+++ b/uip/uip_arch.h
@@ -81,7 +81,7 @@
  *
  * \param op16 A 16-bit integer in host byte order.
  */
-void uip_add32(u8_t __xdata * op32, u16_t op16);
+void uip_add32(__xdata u8_t * op32, u16_t op16);
 
 /**
  * Calculate the Internet checksum over a buffer.


### PR DESCRIPTION
When no memory type is specified in a call-argument to the reference type, sdcc is
using a helper functions, `__gptrput()` and `__gptrget()`, to access that location.
This can be useful to make functions generic.
But sdcc is using an extra call-register to tell the helper functions which memory-type is used.
This registers must also be preserved until all access to that location is done.

To find all the  `__gptrput()` and `__gptrget()`.
Compile the code as normal.
Then use this command `rg  "__gptr" output/` to see if there is a hit.
Look in the .lst file to see in which file and location this occurs.

note: `cmd_compare()` is not fixed, will be fixed in #201 

Code-size saved: +650-bytes
```patch
<    EXTERNAL RAM     0x0001   0x2623    9763    16777216
<    ROM/EPROM/FLASH  0x0000   0x2c091  88685    16777216
---
>    EXTERNAL RAM     0x0001   0x2613    9747    16777216
>    ROM/EPROM/FLASH  0x0000   0x2bf1b  88018    16777216
```