### PR TITLE
Makefile: Improve filenames of images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,21 @@ BUILDDIR = output
 VERSION_HEADER := version.h
 
 ifeq ($(MACHINE),)
+	MACHINE:= $(shell grep "^\s*#define MACHINE_" machine.h | sed "s/^\s*#define MACHINE_//")
 else
 	CC_FLAGS += -DMACHINE_$(MACHINE)
 endif
 
-all: create_build_dir $(VERSION_HEADER) $(SUBDIRS) $(BUILDDIR)/rtlplayground.bin
+GIT_VERSION := $(shell git rev-parse --short HEAD)
+ifeq ($(shell git status --porcelain),) then
+else
+	GIT_VERSION := $(GIT_VERSION)-dirty
+endif
+
+VERSION_EXTENSION = v$(VERSION)-$(GIT_VERSION)
+FILENAME_EXTENSION = $(VERSION_EXTENSION)-$(MACHINE)
+
+all: create_build_dir $(VERSION_HEADER) $(SUBDIRS) $(BUILDDIR)/rtlplayground-$(FILENAME_EXTENSION).bin
 
 create_build_dir:
 	mkdir -p $(BUILDDIR)
@@ -41,7 +51,7 @@ html_data.c html_data.h: $(HTML) tools/$(BUILDDIR)/fileadder
 $(VERSION_HEADER):
 	@echo "#ifndef VERSION_H" > $(VERSION_HEADER)
 	@echo "#define VERSION_H" >> $(VERSION_HEADER)
-	@echo "#define VERSION_SW \"v$(VERSION)-g$(shell git rev-parse --short HEAD)\"" >> $(VERSION_HEADER)
+	@echo "#define VERSION_SW \"$(VERSION_EXTENSION)\"" >> $(VERSION_HEADER)
 	@echo "#define BUILD_DATE \"$(shell date +"%Y-%m-%d %H:%M:%S")\"" >> $(VERSION_HEADER)
 	@echo "#endif" >> $(VERSION_HEADER)
 
@@ -67,14 +77,14 @@ $(BUILDDIR)/rtlplayground.ihx: $(OBJS) $(BUILDDIR)/crtstart.rel $(BUILDDIR)/crc1
 $(BUILDDIR)/rtlplayground.img: $(BUILDDIR)/rtlplayground.ihx
 	objcopy --input-target=ihex -O binary $< $@
 
-$(BUILDDIR)/rtlplayground.bin: $(BUILDDIR)/rtlplayground.img
+$(BUILDDIR)/rtlplayground-$(FILENAME_EXTENSION).bin: $(BUILDDIR)/rtlplayground.img
 	if [ -e $@ ]; then rm $@; fi
 	tools/$(BUILDDIR)/imagebuilder -i $^ $@
 	tools/$(BUILDDIR)/fileadder -a $(DEFAULT_CONFIG_LOCATION) -s $(IMAGESIZE) -d config.txt $@
 	tools/$(BUILDDIR)/fileadder -a $(CONFIG_LOCATION) -s $(IMAGESIZE) -d config.txt $@
 	tools/$(BUILDDIR)/fileadder -a $(HTML_LOCATION) -s $(IMAGESIZE) -d html -p html_data -b BANK1 $@
 	tools/$(BUILDDIR)/crc_calculator -u $@
-
+	ln -sf rtlplayground-$(FILENAME_EXTENSION).bin $(BUILDDIR)/rtlplayground.bin
 
 .PHONY: clean all $(SUBDIRS) $(VERSION_HEADER)
 

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ $(SUBDIRS):
 
 clean:
 	-rm -f html_data.c html_data.h $(VERSION_HEADER)
+	-if [ -d $(BUILDDIR) ]; then find $(BUILDDIR) -type f ! -name "*.bin" -delete; fi
+
+distclean:
+	-rm -f html_data.c html_data.h $(VERSION_HEADER)
 	-rm -rf $(BUILDDIR)
 
 $(BUILDDIR)/%.rel: %.c

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else
 endif
 
 GIT_VERSION := $(shell git rev-parse --short HEAD)
-ifeq ($(shell git status --porcelain),) then
+ifeq ($(shell git status --porcelain --untracked-files=no),)
 else
 	GIT_VERSION := $(GIT_VERSION)-dirty
 endif

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -6,37 +6,36 @@ CC_FLAGS = -mmcs51
 ASM = sdas8051
 AFLAGS= -plosgff
 
-BUILDDIR = output/
+BUILDDIR = output
 
 SRCS = installer.c
-OBJS = ${SRCS:%.c=$(BUILDDIR)%.rel}
+OBJS = ${SRCS:%.c=$(BUILDDIR)/%.rel}
 
-all: create_build_dir $(BUILDDIR)updatebuilder $(BUILDDIR)rtlplayground.bin
+all: create_build_dir $(BUILDDIR)/updatebuilder $(BUILDDIR)/rtlplayground_oem_upgrade.bin
 
 create_build_dir:
 	mkdir -p $(BUILDDIR)
 
-$(BUILDDIR)updatebuilder: updatebuilder.c
+$(BUILDDIR)/updatebuilder: updatebuilder.c
 	gcc $^ -o $@
 
-$(BUILDDIR)installer.rel: installer.c
+$(BUILDDIR)/installer.rel: installer.c
 	$(CC) $(CC_FLAGS) --code-loc ${CODE_LOCATION} -o $@ -c $<
 
-$(BUILDDIR)crtstart.rel: crtstart.asm
+$(BUILDDIR)/crtstart.rel: crtstart.asm
 	$(ASM) $(AFLAGS) -o $@ $<
 
-$(BUILDDIR)%.rel: $(BUILDDIR)%.asm
+$(BUILDDIR)/%.rel: $(BUILDDIR)/%.asm
 	${ASM} ${AFLAGS} -o $@ $^
 
-$(BUILDDIR)%.rel: %.c
+$(BUILDDIR)/%.rel: %.c
 	$(CC) $(CC_FLAGS) -o $@ -c $<
 
-$(BUILDDIR)rtlinstaller.ihx: $(BUILDDIR)crtstart.rel $(OBJS)
+$(BUILDDIR)/rtlinstaller.ihx: $(BUILDDIR)/crtstart.rel $(OBJS)
 	$(CC) $(CC_FLAGS) -Wl-bHOME=${INSTALLER_ADDRESS} -Wl-r -o $@ $^
 
-$(BUILDDIR)rtlplayground.bin: $(BUILDDIR)rtlinstaller.ihx ../$(BUILDDIR)/rtlplayground.bin
-	cp ../$(BUILDDIR)/rtlplayground.bin $(BUILDDIR)
-	./$(BUILDDIR)/updatebuilder -i $< $(BUILDDIR)rtlplayground.bin
+$(BUILDDIR)/rtlplayground_oem_upgrade.bin: $(BUILDDIR)/rtlinstaller.ihx ../$(BUILDDIR)/rtlplayground.bin
+	./$(BUILDDIR)/updatebuilder -i $< -o $(BUILDDIR)/rtlplayground_oem_upgrade.bin ../$(BUILDDIR)/rtlplayground.bin
 
 clean:
 	rm -r $(BUILDDIR)


### PR DESCRIPTION
1. `rtlplayground.bin` renamed to reflect MACHINE and git-revision in the filename.
Kept a symbolic link to the latest output for compatibility reasons - makes it also easier for automatic deployment in case one uses additional scripts.

```
~/RTLPlayground$ ls -l output/*.bin
lrwxrwxrwx 1 user user     49 May  2 21:42 output/rtlplayground.bin -> rtlplayground-v0.1.0-09d90d6-dirty-HI_K0402WS.bin
-rw------- 1 user user 524288 May  2 21:42 output/rtlplayground-v0.1.0-09d90d6-dirty-HI_K0402WS.bin
```

2. Output of installer dir renamed `rtlplayground_oem_upgrade.bin` to avoid confusion with `rtlplayground.bin`.