### PR TITLE
Support for executing multiple commands via /cmd

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -1639,3 +1639,37 @@ config_done:
 	clear_command_history();
 	save_cmd = 1;
 }
+
+// Execute multiple commands
+// If a command is too long or can't be tokenized, remaining commands are not executed
+// Returns the status via `err_status`-variable.
+void execute_commands(__xdata uint8_t *p) __banked {
+	err_status = ERR_OK;
+	uint8_t cmd_idx = 0;
+	while (1) {
+		if (*p == 0 || *p == '\n' || *p == '\r') {
+			if (cmd_idx) {
+				cmd_buffer[cmd_idx] = '\0';
+				cmd_tokenize();
+				if (err_status != ERR_OK)
+					return;
+				cmd_parser();
+			}
+			if (*p == 0)
+				return;
+			cmd_idx = 0;
+		} else {
+			if (cmd_idx < (CMD_BUF_SIZE - 1)) {
+				cmd_buffer[cmd_idx++] = *p;
+			} else {
+				cmd_buffer[CMD_BUF_SIZE - 1] = '\0';
+				print_string("ERROR: Command too long: ");
+				print_string_x(cmd_buffer);
+				write_char('\n');
+				err_status = ERR_CMD_TOO_LONG;
+				return;
+			}
+		}
+		p++;
+	};
+}

--- a/cmd_parser.h
+++ b/cmd_parser.h
@@ -7,10 +7,13 @@
 
 extern __xdata uint8_t cmd_buffer[CMD_BUF_SIZE];
 extern __xdata uint8_t cmd_available;
+extern __xdata uint8_t err_status;
 
 void cmd_tokenize(void) __banked;
 void cmd_parser(void) __banked;
 void execute_config(void) __banked;
+void execute_commands(__xdata uint8_t *p) __banked;
 void print_sw_version(void) __banked;
 void clear_command_history(void) __banked;
+
 #endif

--- a/html/system.js
+++ b/html/system.js
@@ -12,18 +12,19 @@ async function ipSub() {
     if (!checkIp(document.getElementById(ips[i]).value))
       return;
   }
+  var cmd = '';
   for (let i=0; i<3;i++){
-    var cmd = ips[i]+' '+document.getElementById(ips[i]).value;
-    try {
-      const response = await fetch('/cmd', {
-        method: 'POST',
-        body: cmd
-      });
-      console.log('Completed!', response);
-      fetchIP();
-    } catch(err) {
-      console.error(`Error: ${err}`);
-    }
+    cmd += ips[i]+' '+document.getElementById(ips[i]).value+'\n';
+  }
+  try {
+    const response = await fetch('/cmd', {
+      method: 'POST',
+      body: cmd
+    });
+    console.log('Completed!', response);
+    fetchIP();
+  } catch(err) {
+    console.error(`Error: ${err}`);
   }
 }
 

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -400,17 +400,16 @@ void handle_post(void)
 	}
 
 	if (is_word(request_path, "cmd")) {
-		register uint8_t i = 0;
 		p += 4;
 		if (!authenticated) {
 			send_unauthorized();
 			return;
 		}
-		while (*p && *p != '\n' && *p != '\r')
-			cmd_buffer[i++] = *p++;
-		cmd_buffer[i] = '\0';
-		if (i)
-			cmd_available = 1;
+		execute_commands(p);
+		if (err_status != ERR_OK) {
+			send_bad_request();
+			return;
+		}
 	} else if (is_word(request_path, "login")) {
 		dbg_string("POST login\n");
 		p += 8; // Read also over "pwd="

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -28,7 +28,6 @@
 
 extern __code const struct machine machine;
 extern __xdata uint32_t flash_size;
-extern __xdata uint8_t err_status;
 
 extern __xdata uint16_t crc_value;
 __xdata struct machine_runtime machine_detected;


### PR DESCRIPTION
Allow multiple commands in a single http /cmd request.
Commands can be separated with \r and/or \n

This should fix issue #134
It could also be useful for atomic changes of vlan settings etc.

Example with curl:
```
#!/bin/bash

IP=192.168.10.247
PASSWORD=1234

IP_NEW=192.168.10.248
PASSWORD_NEW=admin

COMMANDS="
ip 192.168.10.248
gw 192.168.10.2
netmask 255.255.252.0
passwd admin
vlan 1
vlan 101 1 2 8t
vlan 102 3 4 8t
vlan 103 5 6 8t
vlan 104 7 8t 9
pvid 1 101
pvid 2 101
pvid 3 102
pvid 4 102
pvid 5 103
pvid 6 103
pvid 7 104
pvid 8 101
pvid 9 104
ingress 1u
ingress 2u
ingress 3u
ingress 4u
ingress 5u
ingress 6u
ingress 7u
ingress 8t
ingress 9u
vlan 101 mgmt
"

curl --cookie-jar cookie.txt --data "pwd=${PASSWORD}" http://${IP}/login
curl --max-time 5 --cookie cookie.txt --data "${COMMANDS}" http://${IP}/cmd

curl --cookie-jar cookie.txt --data "pwd=${PASSWORD_NEW}" http://${IP_NEW}/login
curl --cookie cookie.txt http://${IP_NEW}/information.json
```

Note that the implementation is far from perfect:
* Commands are processed sequentially and some limited checks are performed on command length and tokenization. If a check fails, the remaining commands are not executed. It would be better if all commands were validated first and then applied atomically if all were valid.
* Settings are applied immediately, so no http response will be received if the IP settings are changed
* A http 400 response does not report what was wrong.
