### PR TITLE
fix: rtl837x_stp bug, cmpMac always 0 when checking for new root

### DIFF
--- a/rtl837x_stp.c
+++ b/rtl837x_stp.c
@@ -136,7 +136,7 @@ void stp_in(void) __banked
 //	print_string("Flags: "); print_byte(STP_I->flags); write_char('\n');
 	print_string("Check new Root\n");
 	if (STP_I->root.prio < root_bridge.prio
-		|| ((STP_I->root.prio == root_bridge.prio) && cmpMAC(STP_I->root.mac, STP_I->root.mac) < 0)) {
+		|| ((STP_I->root.prio == root_bridge.prio) && cmpMAC(STP_I->root.mac, root_bridge.mac) < 0)) {
 		print_string("Updating Root bridge\n");
 			root_bridge.prio = STP_I->root.prio;
 			memcpy(root_bridge.mac, STP_I->root.mac, 6);


### PR DESCRIPTION
When checking for a new root, a root_bridge with the same priority as STP_I will never be adopted as cmpMAC always returns 0.

This PR fixes this bug by changing the comparison of MACs to what was intended