### PR TITLE
Fix VLAN name persistence across rename and delete operations

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -331,6 +331,8 @@ void parse_vlan(void)
 	vlan_settings.vlan = 0;
 	vlan_settings.members = 0;
 	vlan_settings.tagged = 0;
+	if (cmd_words_len < 2)
+		goto err;
 	if (!atoi_short(&vlan_settings.vlan, cmd_words_b[1])) {
 		if (cmd_words_len == 3 && cmd_buffer[cmd_words_b[2]] == 'd') {
 			vlan_delete(vlan_settings.vlan);
@@ -351,7 +353,7 @@ void parse_vlan(void)
 			vlan_names[vlan_ptr++] = hex[(vlan_settings.vlan >> 8) & 0xf];
 			vlan_names[vlan_ptr++] = hex[(vlan_settings.vlan >> 4) & 0xf] ;
 			vlan_names[vlan_ptr++] = hex[vlan_settings.vlan & 0xf];
-			while(cmd_buffer[cmd_words_b[w] + i] != ' ') {
+			while(cmd_buffer[cmd_words_b[w] + i] != ' ' && cmd_buffer[cmd_words_b[w] + i] != '\0') {
 				write_char(cmd_buffer[cmd_words_b[w] + i]);
 				vlan_names[vlan_ptr++] = cmd_buffer[cmd_words_b[w] + i++];
 			}

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -347,6 +347,7 @@ void parse_vlan(void)
 		uint8_t w = 2;
 		if (cmd_words_len > w && isletter(cmd_buffer[cmd_words_b[w]])) {
 			register uint8_t i = 0;
+			vlan_name_remove(vlan_settings.vlan);
 			vlan_names[vlan_ptr++] = hex[(vlan_settings.vlan >> 8) & 0xf];
 			vlan_names[vlan_ptr++] = hex[(vlan_settings.vlan >> 4) & 0xf] ;
 			vlan_names[vlan_ptr++] = hex[vlan_settings.vlan & 0xf];

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -116,8 +116,42 @@ uint16_t port_pvid_get(uint8_t port) __banked
 void vlan_delete(uint16_t vlan) __banked
 {
 	print_string("\nvlan_delete called \n"); print_short(vlan);
+	vlan_name_remove(vlan);
 	REG_WRITE(RTL837x_TBL_DATA_IN_A, 0, 0, 0, 0);
 	REG_WRITE(RTL837X_TBL_CTRL, vlan >> 8, vlan, TBL_VLAN, TBL_WRITE | TBL_EXECUTE);
+}
+
+
+void vlan_name_remove(uint16_t vlan) __banked
+{
+	static __xdata uint16_t name_pos;
+	static __xdata uint16_t entry_start;
+	static __xdata uint16_t pos;
+	static __xdata uint16_t entry_len;
+	static __xdata uint16_t move_count;
+	static __xdata uint16_t j;
+
+	name_pos = vlan_name(vlan);
+	if (name_pos == 0xffff)
+		return;
+
+	entry_start = name_pos - 3;
+	pos = entry_start;
+
+	while (pos < vlan_ptr && vlan_names[pos] != ' ')
+		pos++;
+	if (pos >= vlan_ptr)
+		return;
+	pos++;
+
+	entry_len = pos - entry_start;
+	move_count = vlan_ptr - pos;
+
+	for (j = 0; j < move_count; j++)
+		vlan_names[entry_start + j] = vlan_names[pos + j];
+
+	vlan_ptr -= entry_len;
+	vlan_names[vlan_ptr] = 0;
 }
 
 

--- a/rtl837x_port.h
+++ b/rtl837x_port.h
@@ -50,6 +50,7 @@ void port_l2_learned(void) __banked;
 void port_stats_print(void) __banked;
 int8_t vlan_get(register uint16_t vlan) __banked;
 __xdata uint16_t vlan_name(register uint16_t vlan) __banked;
+void vlan_name_remove(uint16_t vlan) __banked;
 void vlan_setup(void) __banked;
 void port_pvid_set(uint8_t port, __xdata uint16_t pvid) __banked;
 uint16_t port_pvid_get(uint8_t port) __banked;


### PR DESCRIPTION
## Problem

VLAN names cannot be changed after they have been set once. Examples:

- `vlan 20 IoT p1u; vlan 20 IoT2` → still shows `IoT`
- `vlan 20 d; vlan 20 NewName p1u` → still shows `IoT`

## Root cause

`vlan_names[]` is an append-only buffer. `vlan_name()` returns the
first matching entry for a given VLAN ID. On update, new entries are
appended without removing the old one; on delete, the name entry is
left behind. The old name always wins.

## Fix

New helper function `vlan_name_remove(vlan)` in `rtl837x_port.c` that
locates the entry for a VLAN ID and removes it via array compaction.
It is called in two places:

- `parse_vlan()` in `cmd_parser.c`, before appending a new name entry
- `vlan_delete()` in `rtl837x_port.c`, when removing a VLAN

The implementation reuses the existing `vlan_name()` lookup, scans
forward to the trailing space of the matched entry, then shifts the
remaining bytes left with a manual `for` loop (SDCC 8051's `memmove()`
is not reliable for the overlap pattern needed here).

Locals are declared as `static __xdata` to avoid the OSEG overlay
segment limit on banked functions — six `uint16_t` autos in a banked
function exceed what SDCC's call-graph analysis can overlay.

## Tested on

KeepLiNK KP-9000-6XH-X (RTL8372 + RTL8221B):

- `vlan 99 AAA p1u; vlan 99 BBB` → name correctly updated to `BBB`
- `vlan 99 d; vlan 99 CCC p1u` → name correctly `CCC`, not stale `AAA`

## Code size impact

- Bank 2: +21 bytes
- Bank 0/1 unchanged

## Notes

Persistence across reboot is a separate issue that lives in the
existing `/config` download/upload workflow and is not part of this
PR.

## Disclosure

This PR was developed with AI assistance (Claude). Code was 
reviewed, hardware-tested on a KeepLiNK KP-9000-6XH-X, and I take 
full responsibility for the changes.