### PR TITLE
Correct argument count for regset command

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -787,7 +787,7 @@ void parse_regset(void)
 {
 	uint16_t reg = 0;
 
-	if (cmd_words_len != 2) {
+	if (cmd_words_len != 3) {
 		goto err;
 	}
 


### PR DESCRIPTION
Fixes: 2cdab5f9d9038266 ("parse_reg{set,get}() make use cmd_words_len.")