### PR TITLE
Broaden range of SFP+ rates mapped to SDS_10GR

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1173,7 +1173,7 @@ static inline uint8_t sfp_rate_to_sds_config(register uint8_t rate)
 		return SDS_1000BX_FIBER;
 	if (rate >= 0x19 && rate <= 0x20)  // Ethernet 2.5 GBit
 		return SDS_HSG;
-	if (rate > 0x65 && rate < 0x70)
+	if (rate >= 0x63 && rate < 0x70)
 		return SDS_10GR;
 	return 0xff;
 }


### PR DESCRIPTION
A commonly used SFP+ form-factor XGS-PON ONT (WAS-110) reports 0x63 at power on and then switches to 0x64 after booting up.

0x63 -> 9.9gbps
0x64 -> 10gbps

These are outside of the previous 0x66-0x69 range which prevented the link from ever being brought up.