### PR TITLE
Add PCB-SWTG024AS-A-V2.0.1_19950

### DIFF
--- a/machine.c
+++ b/machine.c
@@ -778,6 +778,57 @@ void machine_custom_init(void)
     reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
 }
 
+
+#elif defined MACHINE_PCB_SWTG024AS_A_2_0_1_19650
+__code const struct machine machine = {
+    .machine_name = "PCB-SWTG024AS-A-2.0.1_19650",
+    .isRTL8373 = 0,
+    .min_port = 3,
+    .max_port = 8,
+    .n_sfp = 2,
+    .log_to_phys_port = {0, 0, 0, 6, 1, 2, 3, 4, 5},
+    .phys_to_log_port = {4, 5, 6, 7, 8, 3, 0, 0, 0},
+    .is_sfp = {0, 0, 0, 2, 0, 0, 0, 0, 1},
+
+    // Left SFP port
+    .sfp_port[1].pin_detect = GPIO38,
+    .sfp_port[1].pin_los = GPIO_NA,
+    .sfp_port[1].sds = 1,
+    .sfp_port[1].i2c =  { .sda = GPIO39_I2C_SDA4, .scl = GPIO40_I2C_SCL3_MDC1 },
+
+    // Right SFP port
+    .sfp_port[0].pin_detect = GPIO37,
+    .sfp_port[0].pin_los = GPIO_NA,
+    .sfp_port[0].sds = 0,
+    .sfp_port[0].i2c = { .sda = GPIO41_I2C_SDA3_MDIO1, .scl = GPIO40_I2C_SCL3_MDC1 },
+
+    .reset_pin = GPIO_NA,
+    .high_leds = { .mux =  LED_28_SYS | LED_29, .enable = LED_27 | LED_28_SYS | LED_29 },
+    .port_led_set = { 0, 0, 0, 1, 0, 0, 0, 0, 1},
+    .led_sets = {
+                    {
+                            LEDS_2G5 | LEDS_LINK | LEDS_10M | LEDS_ACT,
+                            LEDS_1G | LEDS_100M | LEDS_10M | LEDS_LINK | LEDS_ACT | LEDS_10G,
+                            LEDS_1G | LEDS_LINK,
+                            0
+                    },
+                    {
+                            LEDS_10G | LEDS_2G5 | LEDS_1G | LEDS_100M | LEDS_10M | LEDS_LINK,
+                            LEDS_10G | LEDS_2G5 | LEDS_1G | LEDS_100M | LEDS_10M | LEDS_ACT,
+                            0,
+                            0
+                    },
+     },
+    .led_mux_custom = 1,
+    .led_mux = {
+                            0x00,0x01,0x04,0x05,0x08,0x09,0x0c,0x3f,0x0d,0x10,0x11,0x0e,0x14,0x11,0x12,0x15,0x15,0x16,0x18,0x19,0x1a,0x19,0x1d,0x1e,0x1c,0x1d,0x20,0x21
+            },
+    };
+
+void machine_custom_init(void) { }
+
+
+
 #else
 	#error "Please select a machine type in machine.h"
 #endif

--- a/machine.c
+++ b/machine.c
@@ -779,9 +779,9 @@ void machine_custom_init(void)
 }
 
 
-#elif defined MACHINE_PCB_SWTG024AS_A_2_0_1_19650
+#elif defined MACHINE_PCB_SWTG024AS_A_2_0_1
 __code const struct machine machine = {
-    .machine_name = "PCB-SWTG024AS-A-2.0.1_19650",
+    .machine_name = "PCB-SWTG024AS-A-2.0.1",
     .isRTL8373 = 0,
     .min_port = 3,
     .max_port = 8,

--- a/machine.h
+++ b/machine.h
@@ -25,7 +25,7 @@
 // #define MACHINE_DEFAULT_8C_1SFP
 // #define MACHINE_HI_K0801WS
 // #define MACHINE_FNS1200P
-#define MACHINE_PCB_SWTG024AS_A_2_0_1_19650
+// #define MACHINE_PCB_SWTG024AS_A_2_0_1
 
 typedef struct {
 	// GPIO pins for SDA/SCL

--- a/machine.h
+++ b/machine.h
@@ -25,6 +25,7 @@
 // #define MACHINE_DEFAULT_8C_1SFP
 // #define MACHINE_HI_K0801WS
 // #define MACHINE_FNS1200P
+#define MACHINE_PCB_SWTG024AS_A_2_0_1_19650
 
 typedef struct {
 	// GPIO pins for SDA/SCL


### PR DESCRIPTION
Add PCB-SWTG024AS-A-V2.0.1_19950, used in Horaco SWTG124AS and ZX-SG4T2.

https://github.com/logicog/RTLPlayground/issues/191