### PR TITLE
Fix SFP led for 2.5gbit for MACHINE_SWGT024_V2_0

### DIFF
--- a/machine.c
+++ b/machine.c
@@ -266,15 +266,19 @@ __code const struct machine machine = {
 	.sfp_port[1].i2c = { .sda = GPIO41_I2C_SDA3_MDIO1, .scl = GPIO40_I2C_SCL3_MDC1 }, /* GPIO 40 */
 	.reset_pin = GPIO54_ACL_BIT2_EN,
 	.high_leds = { .mux = LED_27 | LED_29, .enable = LED_28_SYS | LED_29 },
-	.port_led_set = { 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	.port_led_set = { 0, 0, 0, 1, 0, 0, 0, 0, 1},
 	.led_sets = {
-		{
-			/* Green LED */
+		{ /* RJ45: Green LED */
 			LEDS_1G | LEDS_100M | LEDS_10M | LEDS_LINK | LEDS_ACT | LEDS_10G,
 			0,
 			/* Amber LED */
 			LEDS_2G5 | LEDS_LINK | LEDS_ACT,
 			0
+		}, { /* SFP PORT: SINGLE GREEN LED */
+			LEDS_10M | LEDS_100M | LEDS_1G | LEDS_2G5 | LEDS_10G | LEDS_LINK | LEDS_ACT,
+			0,
+			0,
+			0,
 		},
 	},
 };
@@ -305,15 +309,19 @@ __code const struct machine machine = {
 	.sfp_port[1].i2c = { .sda = GPIO41_I2C_SDA3_MDIO1, .scl = GPIO40_I2C_SCL3_MDC1 }, /* GPIO 40 */
 	.reset_pin = GPIO_NA,
 	.high_leds = { .mux = LED_27 | LED_29, .enable = LED_28_SYS | LED_29 },
-	.port_led_set = { 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	.port_led_set = { 0, 0, 0, 1, 0, 0, 0, 0, 1},
 	.led_sets = {
-		{
-			/* Green LED */
+		{ /* RJ45: Green LED */
 			LEDS_1G | LEDS_100M | LEDS_10M | LEDS_LINK | LEDS_ACT | LEDS_10G,
 			0,
 			/* Amber LED */
 			LEDS_2G5 | LEDS_LINK | LEDS_ACT,
 			0
+		}, { /* SFP PORT: SINGLE GREEN LED */
+			LEDS_10M | LEDS_100M | LEDS_1G | LEDS_2G5 | LEDS_10G | LEDS_LINK | LEDS_ACT,
+			0,
+			0,
+			0,
 		},
 	},
 };


### PR DESCRIPTION
While testing #246, I noticd that SFP did not light-up while forcing 2.5gbit link. This is because RJ45 and SFP share the same LED-settings. But RJ45 has two leds-settings.
Solution is to add settings for SFP for both managed and unmanaged variant.