### PR TITLE
Don't disable flash DIO operation before flashing

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -521,7 +521,6 @@ void handle_post(void)
 		dbg_string("Have content octets\n");
 		p += 4; // Skip \r\n\r\n sequence at end of preamble of part
 
-		flash_init(0); // Re-initialize flash for non-DIO operation, otherwise flashing fails
 		set_sys_led_state(SYS_LED_FAST);
 
 		crc_value = 0;

--- a/installer/installer.c
+++ b/installer/installer.c
@@ -361,9 +361,6 @@ void installer(void)
 	setup_serial_timer1();
 	print_string("\nRTLPlayground installer starting...\n");
 
-	// Initialize flash functions with disable DIO because writing does not work otherwise
-	flash_init(0);
-
 	__xdata uint32_t dest = 0x0;
 	__xdata uint32_t source = UPDATE_CODE_LOC;
 	// A 512kByte = 4MBit Flash has 128 sectors, we copy only 120

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1884,7 +1884,6 @@ void check_and_flash_update_image(void)
 		__xdata uint16_t j = 0;
 		__xdata uint8_t * __xdata bptr;
 		print_string("found update image!\nChecking integrity");
-		flash_init(0); // Re-initialize flash for non-DIO operation, otherwise flashing will fail
 		set_sys_led_state(SYS_LED_FAST);
 		crc_value = 0x0000;
 		for (i = 0; i < 1024; i++) {


### PR DESCRIPTION
After playing with the SPI flash, I wondered if switching to Non-DIO operation is still needed. I once added this beacuse it did not work otherwise.
However, for some reason, it DOES work now without switching the mode, therefore removing the lines.