### PR TITLE
Fix conf_overwrite filter removing vlan mgmt entries

### DIFF
--- a/html/config.js
+++ b/html/config.js
@@ -14,6 +14,7 @@ const conf_cmds = [
   /^pvid\s+\d{1,2}\s+\d{1,4}$/,
   /^ingress(\s+\d{1,2}[tua])+$/,
   /^ingress\s+[tua]$/,
+  /^port\s+\d{1,2}\s+(10m|100m|1g|2g5|5g|10g|auto|on|off)(\s+(half|full))?$/,
   /^port\s+\d{1,2}\s+name\s+\S+$/,
   /^eee(\s+\d{1,2})?\s+(on|off)$/,
   /^mirror(\s+\d{1,2})(\s+\d{1,2}[tr]?)+$/,
@@ -36,6 +37,7 @@ const conf_overwrite = [
   /^vlan\s+\d{1,4}(?!\s+mgmt\b)/,
   /^pvid\s+\d{1,2}\b/,
   /^ingress\b/,
+  /^port\s+\d{1,2}(?!\s+name\b)/,
   /^port\s+\d{1,2}\s+name\b/,
   /^eee\s+\d{1,2}\b/,
   /^eee\b/,
@@ -71,7 +73,7 @@ function parseConf(s){
         let m = line.match(x);
         let matchStr = m[0];
         configuration = configuration.filter(item =>
-          !(item === matchStr || (item.startsWith(matchStr + " ") && !item.endsWith(" mgmt"))));
+          !(item === matchStr || (item.startsWith(matchStr + " ") && !item.endsWith(" mgmt") && !item.startsWith(matchStr + " name "))));
         break;
       }
     }

--- a/html/config.js
+++ b/html/config.js
@@ -71,7 +71,7 @@ function parseConf(s){
         let m = line.match(x);
         let matchStr = m[0];
         configuration = configuration.filter(item =>
-          !(item === matchStr || item.startsWith(matchStr + " ")));
+          !(item === matchStr || (item.startsWith(matchStr + " ") && !item.endsWith(" mgmt"))));
         break;
       }
     }

--- a/html/config.js
+++ b/html/config.js
@@ -59,8 +59,7 @@ function parseConf(s){
     const deleteMatch = line.match(/^vlan\s+(\d{1,4})\s+d$/);
     if (deleteMatch) {
       const prefix = "vlan " + deleteMatch[1] + " ";
-      configuration = configuration.filter(c =>
-        c !== "vlan " + deleteMatch[1] && !c.startsWith(prefix));
+      configuration = configuration.filter(c => !c.startsWith(prefix));
       continue;
     }
     console.log(l + ' --> ' + line);

--- a/html/config.js
+++ b/html/config.js
@@ -77,6 +77,9 @@ function parseConf(s){
         break;
       }
     }
+    // Only one management VLAN can be active, so drop any previous mgmt entry
+    if (/^vlan\s+\d{1,4}\s+mgmt$/.test(line))
+      configuration = configuration.filter(item => !/^vlan\s+\d{1,4}\s+mgmt$/.test(item));
     configuration.push(line);
   }
   console.log("Configuration now:");


### PR DESCRIPTION
Follow-up to #237 (the vlan/mgmt lookahead fix). The pattern separation
was correct, but the conf_overwrite filter still used
`startsWith("vlan N ")`, which also matched `vlan N mgmt` — so the
management entry got dropped whenever a VLAN's membership was re-saved.

One-line guard (`!item.endsWith(" mgmt")`) so mgmt entries survive.