### PR TITLE
Automatically print newline on serial interface

### DIFF
--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -120,6 +120,7 @@ extern __xdata struct uip_eth_addr uip_ethaddr;
 
 // Headers for calls in the common code area (HOME/BANK0)
 void print_string_no_syslog(__code char *p);
+void print_string_newline_no_syslog(__code char *p);
 void print_string(__code char *p);
 void print_string_x(__xdata char *p);
 void print_long(uint32_t a);

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -271,6 +271,12 @@ void print_string_no_syslog(__code char *p)
 		write_char_no_syslog(*p++);
 }
 
+void print_string_newline_no_syslog(__code char *p)
+{
+	write_char_no_syslog('\n');
+	print_string_no_syslog(p);
+}
+
 void print_string_x(__xdata char *p)
 {
 	while (*p)

--- a/syslog.c
+++ b/syslog.c
@@ -30,16 +30,16 @@ void syslog_start(void) __banked
 		uip_ipaddr(server_ip, state.server_ip[0], state.server_ip[1], state.server_ip[2], state.server_ip[3]);
 		state.syslog_conn = uip_udp_new(&server_ip, HTONS(514));
 		if (state.syslog_conn == 0) {
-			print_string_no_syslog("Failed to create a new UDP client\n");
+			print_string_newline_no_syslog("Failed to create a new UDP client");
 			return;
 		}
-		print_string_no_syslog("Started syslog to IP ");
+		print_string_newline_no_syslog("Started syslog to IP ");
 		itoa(state.server_ip[0]); write_char('.'); itoa(state.server_ip[1]); write_char('.');
 		itoa(state.server_ip[2]); write_char('.'); itoa(state.server_ip[3]); write_char('\n');
 		state.enabled = 1;
 	}
 	else {
-		print_string_no_syslog("Syslog is already running\n");
+		print_string_newline_no_syslog("Syslog is already running");
 	}
 }
 
@@ -49,9 +49,9 @@ void syslog_stop(void) __banked
 	if (state.syslog_conn != 0) {
 		uip_udp_remove(state.syslog_conn);
 		state.syslog_conn = 0;
-		print_string_no_syslog("Stopped syslog\n");
+		print_string_newline_no_syslog("Stopped syslog");
 	} else {
-		print_string_no_syslog("Syslog is not running\n");
+		print_string_newline_no_syslog("Syslog is not running");
 	}
 }
 

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -234,7 +234,7 @@ __xdata struct uip_stats uip_stat;
 #endif /* UIP_STATISTICS == 1 */
 
 #if UIP_LOGGING == 1
-#define UIP_LOG(m) print_string_no_syslog(m);
+#define UIP_LOG(m) print_string_newline_no_syslog(m);
 #else
 #define UIP_LOG(m)
 #endif /* UIP_LOGGING == 1 */


### PR DESCRIPTION
It was a tiny bit nagging to have `tcp: found no unused connections.` print all over on the same line; especially if your terminal does not return to next line on its own.

Nothing major, just visual annoyance.