### PR TITLE
Add support for 100M on RTL8221B ports

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1406,9 +1406,9 @@ void idle(void)
 			cpy_4(linkbits_last, sfr_data);
 			// Handle link change of the RTL8221 PHY, adjust SDS mode, RTL8261BE always uses SDS_QXGMII
 			if (!machine.n_10g && p5_last != p5) {
-				if (p5 == 0x5) // 2.5GBit Mode
+				if (p5 == 0x5)	// 2.5GBit Mode
 					sds_config(0, SDS_HISGMII);
-				else if (p5 == 0x2) // 1GBit
+				else		// 1GBit and 100Mbit
 					sds_config(0, SDS_SGMII);
 			}
 			if (machine.n_10g)


### PR DESCRIPTION
On machines with 5 Ethernet ports, the 5th port is implemented using an RTL8221B-PHY, which is 2.5. The RTL8221B supports 100M by configuring SGMII on the link to the MAC. In RTLPlayground, this port currently only supports 100M, if previously SGMII was configured, i.e. a 1GBit cable was attached. Make this work also for the case where previously a 2.5Gbit cable was attached.