### PR TITLE
Add reset switch to SWTG018AS-A V2.0

### DIFF
--- a/doc/devices/SWTG018AS_A_V2_0.md
+++ b/doc/devices/SWTG018AS_A_V2_0.md
@@ -1,4 +1,10 @@
 # SWTG018AS-A V2.0
+## Brands
+| Brand  | Type             |Managed| PCB              | Flash           | Chip RTL      |
+|--------|------------------|-------|------------------|-----------------|---------------|
+| Ampcom | SWTG018AS-A V2.0 | No    | SWTG018AS-A V2.0 | 2MB             | 8273N + 8224N |
+| Horaco | HC-SWTGW218AS-A  | Yes   | SWTG018AS-A V2.0 | 2MB(25Q16JVSIQ) | 8273N + 8224N |
+
 
 The following is a documentation for the unmanaged switch marked as `SWTG018AS-A V2.0`.
 It is e.g. sold under the Ampcom brand, but no branh-markings are found on the device.

--- a/machine.c
+++ b/machine.c
@@ -344,7 +344,7 @@ __code const struct machine machine = {
 	.sfp_port[0].pin_tx_disable = GPIO_NA,
 	.sfp_port[0].sds = 1,
 	.sfp_port[0].i2c = { .sda = GPIO39_I2C_SDA4, .scl = GPIO40_I2C_SCL3_MDC1 },
-	.reset_pin = GPIO_NA,
+	.reset_pin = GPIO48_I2C_SCL1,
 	.high_leds = { .mux = LED_27 | LED_29, .enable = LED_28_SYS | LED_29 },
 	.port_led_set = { 0, 0, 0, 0, 0, 0, 0, 0, 1},
 	.led_sets = {


### PR DESCRIPTION
Same board used by Horaco HC-SWTGW218AS with populated reset switch.
Tested and working.