### PR TITLE
fix(machine): SWTG024AS V2.0 fix 5th RJ45 port

### DIFF
--- a/doc/devices/SWTG024AS-V2.0.md
+++ b/doc/devices/SWTG024AS-V2.0.md
@@ -17,8 +17,7 @@
 
 ### What works
 The device is fully supported:
-- Port 1-4 2.5GBASE-T RJ45 ports work at 10/100/1000/2500 Mbps
-- Port 5 2.5GBASE-T RJ45 ports through RTL8221B not work (Wait to fix)
+- ALL 2.5GBASE-T RJ45 ports work at 10/100/1000/2500 Mbps
 - The SFP+ port supports 1G, 2.5G and 10G modules 
 - LEDs work with the same indiciations as the OEM firmware
 - Online update does not work with 512KiB flash.

--- a/rtl837x_init.c
+++ b/rtl837x_init.c
@@ -76,6 +76,16 @@ void static sds_init(void)
 				sds_read(0, 0, 0);
 				pval = SFR_DATA_U16;
 				sds_write_v(0, 0, 0, pval | 0x200);
+#if defined MACHINE_SWTG024AS_V2_0
+				// OEM firmware also sets the companion SDS0 polarity bits.
+				sds_read(0, 0, 0);
+				pval = SFR_DATA_U16;
+				sds_write_v(0, 0, 0, pval | 0x100);
+
+				sds_read(0, 6, 2);
+				pval = SFR_DATA_U16;
+				sds_write_v(0, 6, 2, pval | 0x4000);
+#endif
 			}
 		} else if (machine.n_10g == 1) {
 			reg_read_m(RTL837X_CFG_PHY_MDI_REVERSE);


### PR DESCRIPTION
Here is some background on the original issue with the 5th RJ45 port:
In prior builds, the 5th RJ45 port could only handle TX traffic, but failed to receive RX traffic. In short, you could see the tx_good count growing in the management panel, but the rx_good count always stayed at 0.

Following further research and comparison with the dumped stock firmware, I fix the 5th RJ45 port issues via a patch. (not for other machine)

Additionally, I noticed a few different between the project and the stock firmware's behavior. Since they aren't causing any bugs at the moment, I have kept them as-is for now and excluded them from this PR.
