### PR TITLE
update document: SKS3200M-4GPY2XF flash size

### DIFF
--- a/doc/devices/SWTG024AS.md
+++ b/doc/devices/SWTG024AS.md
@@ -10,7 +10,7 @@ Also the RJ45 connectors can be all plastic/non-shielded or with metal shielding
 |---|---|---|---|---|---|---|
 | LIANGUO |SWTG024AS |No|  SWTG024AS-v2.0-17452 | CM-23-11-2336 023-17453| 512 KiB | 8272 |
 | Haraco |ZX-SWTG124AS | Yes |  SWTG024AS-v2.0 | ??? | ??? | 8272 |
-| Xikestore |SKS3200M-4GPY2XF | Yes |  SWTG024AS-v1.0 | CM-23-08-2043 023-16721 | ??? | 8272 |
+| Xikestore |SKS3200M-4GPY2XF | Yes |  SWTG024AS-v1.0 | CM-23-08-2043 023-16721 | 2048 KiB | 8272 |
 | Sodola | SL-SWTG124AS-D | Yes | SWTG024AS-v2.0-17452 | ??? | 2048 KiB | 8272 |
 
 ## PCB


### PR DESCRIPTION
I have the actual device for this switch and have successfully installed RTLPlayground on it. 

I wanted to make a small contribution, so I verified the flash size of this product and updated it accordingly.   
The flash chip used in this device is **FM25Q16A**.

I am available to conduct further investigations or tests on this hardware if needed.  
Please let me know if there is anything else you would like me to check!