### PR TITLE
fix: rename local variable to avoid shadowing global translation

### DIFF
--- a/html/stat.js
+++ b/html/stat.js
@@ -114,7 +114,7 @@ function getCounters(port) {
       const s = JSON.parse(xhttp.responseText);
       console.log("Counters: ", JSON.stringify(s));
       const ptext = document.getElementById('popup_text');
-      var t = "<table style='width:100%'> <tr> <th>" + t('stat_counter') + "</th> <th>" + t('stat_value') + "</th> <th>" + t('stat_counter') + "</th> <th>" + t('stat_value') + "</th></tr> <tr>";
+      var tableHtml = "<table style='width:100%'> <tr> <th>" + t('stat_counter') + "</th> <th>" + t('stat_value') + "</th> <th>" + t('stat_counter') + "</th> <th>" + t('stat_value') + "</th></tr> <tr>";
       console.log("Counter 0: ", BigInt(s[0]).toString(), " length: ", s.length);
       var c = 0;
       for (i = 0; i < mib_counters.length; i += 4) {
@@ -125,28 +125,28 @@ function getCounters(port) {
         }
         var count = BigInt(s[i/4]);
         if (mib_counters[i+1] == 8) {
-          t += "<td>" + mib_counters[i] + "</td><td>" + count.toString() + "</td>";
+          tableHtml += "<td>" + mib_counters[i] + "</td><td>" + count.toString() + "</td>";
           c += 1;
         } else if (mib_counters[i+1] == 4) {
           if (mib_counters[i] != "") {
-            t += "<td>" + mib_counters[i] + "</td><td>" + (count >> 32n).toString() + "</td>";
+            tableHtml += "<td>" + mib_counters[i] + "</td><td>" + (count >> 32n).toString() + "</td>";
             c += 1;
           }
           if (c == 2) {
-            t += "</tr> <tr>";
+            tableHtml += "</tr> <tr>";
             c = 0;
           }
           if (mib_counters[i+2] != "") {
-            t += "<td>" + mib_counters[i+2] + "</td><td>" + (count & 4294967295n).toString() + "</td>";
+            tableHtml += "<td>" + mib_counters[i+2] + "</td><td>" + (count & 4294967295n).toString() + "</td>";
             c += 1;
           }
         }
         if (c == 2) {
-          t += "</tr> <tr>";
+          tableHtml += "</tr> <tr>";
           c = 0;
         }
       }
-      ptext.innerHTML = t + "</tr></table>";
+      ptext.innerHTML = tableHtml + "</tr></table>";
       popup.style.display = 'flex';
     }
   };


### PR DESCRIPTION
Bugs discovered in #283

Commit e75a4c2 introduced i18n support, adding a global t() function for translations. In html/stat.js, the getCounters function already had a local variable var t used to build the table HTML string.
When the translation calls t('stat_counter') and t('stat_value') , JavaScript hoisting caused the local var t declaration to be hoisted to the top of the function scope. 

At the time t('stat_counter') is evaluated, t resolves to the hoisted local variable (still undefined), not the global function — producing Uncaught TypeError: t is not a function.
The fix renames the local variable from t to tableHtml, eliminating the name collision while keeping the global t() function accessible for translations.