### PR TITLE
httpd: fix browser login (cookie parsed by name, Connection: close, self-contained login page)

### DIFF
--- a/html/login.html
+++ b/html/login.html
@@ -19,7 +19,7 @@
   <h1 data-i18n="login_heading"> RTL Switch Login</h1>
   <form method="post" action="login">
   <div class="txt_field">
-    <input name="pwd" type="password" onclick="removeNote()" required />
+    <input name="pwd" type="password" autocomplete="current-password" onclick="removeNote()" required />
     <span></span>
     <label data-i18n="login_password">Password</label>
   </div>

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -204,28 +204,28 @@ uint8_t parse_short(__xdata uint8_t *p)
 
 void send_not_found(void)
 {
-	slen = strtox(outbuf, "HTTP/1.1 404 Not found\r\nContent-Type: text/html\r\n\r\n" \
+	slen = strtox(outbuf, "HTTP/1.1 404 Not found\r\nConnection: close\r\nContent-Type: text/html\r\n\r\n" \
 			      "<!DOCTYPE HTML PUBLIC>\n<title>404 Not Found</title>\n<h1>Not Found</h1>\n");
 }
 
 
 void send_bad_request(void)
 {
-	slen = strtox(outbuf, "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n" \
+	slen = strtox(outbuf, "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Type: text/html\r\n\r\n" \
 			      "<!DOCTYPE HTML PUBLIC>\n<title>400 Bad Request</title>\n<h1>Bad Request</h1>\n");
 }
 
 
 void send_to_login(void)
 {
-	slen = strtox(outbuf, "HTTP/1.1 302 Found\r\n" \
+	slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nConnection: close\r\n" \
 			      "Location: login.html\r\n\r\n");
 }
 
 
 void send_unauthorized(void)
 {
-	slen = strtox(outbuf, "HTTP/1.1 401 Unauthorized\r\n\r\n");
+	slen = strtox(outbuf, "HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
 }
 
 
@@ -469,14 +469,14 @@ void handle_post(void)
 			read_reg_timer(&last_session_use);
 			gen_random_bytes(session_id, SESSION_ID_LENGTH);
 			session_id[SESSION_ID_LENGTH] = '\0';
-			slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nLocation: index.html\r\n" \
+			slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nConnection: close\r\nLocation: index.html\r\n" \
 					      "Set-Cookie: session=");
 			for (register uint8_t i = 0; i < SESSION_ID_LENGTH; i++)
 				outbuf[slen++] = session_id[i];
 			slen += strtox(outbuf + slen, "; SameSite=Strict\r\n\r\n");
 		} else {
 			dbg_string("Password invalid!\n");
-			slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nLocation: login.html\r\n\r\n");
+			slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nConnection: close\r\nLocation: login.html\r\n\r\n");
 		}
 		return;
 	} else if (s->tstate == TSTATE_MULTIPART || is_word(request_path, "upload") || is_word(request_path, "config")) {
@@ -521,7 +521,7 @@ void handle_post(void)
 		send_not_found();
 		return;
 	}
-	slen = strtox(outbuf, "HTTP/1.1 200 OK\r\n\r\n");
+	slen = strtox(outbuf, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n");
 	return;
 bad_request:
 	send_bad_request();
@@ -706,7 +706,16 @@ void httpd_appcall(void)
 			 * explicit, complete policy stops privacy shields (Brave/NoScript)
 			 * from injecting their own restrictive report-only probes that made
 			 * the console noisy and could break the JS-driven pages. */
-			slen += strtox(outbuf + slen, "; charset=UTF-8\r\nCache-Control: max-age=60, must-revalidate\r\nAccess-Control-Allow-Origin: *\r\nContent-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; form-action 'self'\r\n\r\n");
+			/* Connection: close is REQUIRED: this httpd serves exactly one
+			 * request per TCP connection (it uip_close()s after the response),
+			 * but without advertising it a browser keeps the socket in its
+			 * keep-alive pool and reuses it for the next request. The reused
+			 * request (e.g. the login POST after the GET of login.html) then
+			 * hits the already-closed connection and is dropped - and browsers
+			 * do NOT retry a non-idempotent POST, so the login silently fails
+			 * while curl (fresh connection per request) works. Advertising
+			 * close makes the browser open a fresh connection every time. */
+			slen += strtox(outbuf + slen, "; charset=UTF-8\r\nCache-Control: max-age=60, must-revalidate\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nContent-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; form-action 'self'\r\n\r\n");
 
 			len_left = f_data[entry].len;
 			if (len_left > (TCP_OUTBUF_SIZE - slen)) {

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -174,9 +174,7 @@ bool is_word_x(__xdata uint8_t *lhs_str_p, __xdata uint8_t *rhs_str_p)
 		c = *rhs_str_p++;
 
 		if (c == '\0') {
-			/* ';' terminates a cookie value when it is not the last cookie
-			 * in the header ("session=X; other=y") - accept it as a word
-			 * boundary so such a session cookie still authenticates. */
+			/* ';' separates cookies in a Cookie header, so it ends a value too. */
 			if (u != '\0' && u != ' ' && u != '\t' && u != ':' && u != '?' && u != '=' && u != '\n' && u != '\r' && u != ';')
 				return false;
 			return true;
@@ -256,18 +254,10 @@ __xdata uint8_t *scan_header(__xdata uint8_t *p)
 		if (is_word(p, "\nContent-Type:"))
 			content_type = p + 15;
 		else if (is_word(p, "\nCookie:")) {
-			/* The Cookie header may carry SEVERAL cookies ("a=1; session=X"),
-			 * and browsers keep stale cookies for years - e.g. an "admin"
-			 * cookie left over from this switch's vendor firmware. The old
-			 * fixed-offset parse (p + 17) assumed "session=" was the first
-			 * and only cookie, so with any other cookie present it pointed
-			 * into the wrong value, authentication silently failed and the
-			 * UI bounced back to the login page although the password had
-			 * been accepted (worked from curl, which sends only session=).
-			 * Scan the header for the actual "session=" key instead. */
-			/* Match "session" (not "session="): is_word() demands a separator
-			 * after the pattern, and '=' is on its separator list while the
-			 * first byte of the value is not. */
+			/* Scan for the "session" key: the header may hold several
+			 * cookies in any order. Match "session" not "session=" -
+			 * is_word() requires a separator after the match and '=' is
+			 * one, so this also rejects a longer key like "sessionx". */
 			__xdata uint8_t *c = p + 8;	/* past "\nCookie:" */
 			while (*c && *c != '\r' && *c != '\n') {
 				if (is_word(c, "session")) {
@@ -722,22 +712,12 @@ void httpd_appcall(void)
 
 			slen = strtox(outbuf, "HTTP/1.1 200 OK\r\nContent-Type: ");
 			slen += strtox(outbuf + slen, mime_strings[f_data[entry].mime]);
-			/* Complete, first-party CSP: everything the UI needs is same-origin
-			 * (scripts, styles, the SVG port icons, the /*.json fetches and the
-			 * login/cmd form POSTs). 'unsafe-inline' for script covers the inline
-			 * onclick handlers and the small inline <script> on login.html. An
-			 * explicit, complete policy stops privacy shields (Brave/NoScript)
-			 * from injecting their own restrictive report-only probes that made
-			 * the console noisy and could break the JS-driven pages. */
-			/* Connection: close is REQUIRED: this httpd serves exactly one
-			 * request per TCP connection (it uip_close()s after the response),
-			 * but without advertising it a browser keeps the socket in its
-			 * keep-alive pool and reuses it for the next request. The reused
-			 * request (e.g. the login POST after the GET of login.html) then
-			 * hits the already-closed connection and is dropped - and browsers
-			 * do NOT retry a non-idempotent POST, so the login silently fails
-			 * while curl (fresh connection per request) works. Advertising
-			 * close makes the browser open a fresh connection every time. */
+			/* 'unsafe-inline' is needed for the inline onclick handlers
+			 * and the inline <script> on login.html. Connection: close is
+			 * required because this httpd closes the connection after every
+			 * response; without advertising it a browser reuses the socket
+			 * from its keep-alive pool and the next request hits the already
+			 * closed connection (a POST is then dropped without a retry). */
 			slen += strtox(outbuf + slen, "; charset=UTF-8\r\nCache-Control: max-age=60, must-revalidate\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nContent-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; form-action 'self'\r\n\r\n");
 
 			len_left = f_data[entry].len;

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -699,7 +699,14 @@ void httpd_appcall(void)
 
 			slen = strtox(outbuf, "HTTP/1.1 200 OK\r\nContent-Type: ");
 			slen += strtox(outbuf + slen, mime_strings[f_data[entry].mime]);
-			slen += strtox(outbuf + slen, "; charset=UTF-8\r\nCache-Control: max-age=60, must-revalidate\r\nAccess-Control-Allow-Origin: *\r\nContent-Security-Policy: style-src 'self' 'unsafe-inline'\r\n\r\n");
+			/* Complete, first-party CSP: everything the UI needs is same-origin
+			 * (scripts, styles, the SVG port icons, the /*.json fetches and the
+			 * login/cmd form POSTs). 'unsafe-inline' for script covers the inline
+			 * onclick handlers and the small inline <script> on login.html. An
+			 * explicit, complete policy stops privacy shields (Brave/NoScript)
+			 * from injecting their own restrictive report-only probes that made
+			 * the console noisy and could break the JS-driven pages. */
+			slen += strtox(outbuf + slen, "; charset=UTF-8\r\nCache-Control: max-age=60, must-revalidate\r\nAccess-Control-Allow-Origin: *\r\nContent-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; form-action 'self'\r\n\r\n");
 
 			len_left = f_data[entry].len;
 			if (len_left > (TCP_OUTBUF_SIZE - slen)) {

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -174,7 +174,10 @@ bool is_word_x(__xdata uint8_t *lhs_str_p, __xdata uint8_t *rhs_str_p)
 		c = *rhs_str_p++;
 
 		if (c == '\0') {
-			if (u != '\0' && u != ' ' && u != '\t' && u != ':' && u != '?' && u != '=' && u != '\n' && u != '\r')
+			/* ';' terminates a cookie value when it is not the last cookie
+			 * in the header ("session=X; other=y") - accept it as a word
+			 * boundary so such a session cookie still authenticates. */
+			if (u != '\0' && u != ' ' && u != '\t' && u != ':' && u != '?' && u != '=' && u != '\n' && u != '\r' && u != ';')
 				return false;
 			return true;
 		}
@@ -252,8 +255,28 @@ __xdata uint8_t *scan_header(__xdata uint8_t *p)
 			break;
 		if (is_word(p, "\nContent-Type:"))
 			content_type = p + 15;
-		else if (is_word(p, "\nCookie:"))
-			session = p + 17;
+		else if (is_word(p, "\nCookie:")) {
+			/* The Cookie header may carry SEVERAL cookies ("a=1; session=X"),
+			 * and browsers keep stale cookies for years - e.g. an "admin"
+			 * cookie left over from this switch's vendor firmware. The old
+			 * fixed-offset parse (p + 17) assumed "session=" was the first
+			 * and only cookie, so with any other cookie present it pointed
+			 * into the wrong value, authentication silently failed and the
+			 * UI bounced back to the login page although the password had
+			 * been accepted (worked from curl, which sends only session=).
+			 * Scan the header for the actual "session=" key instead. */
+			/* Match "session" (not "session="): is_word() demands a separator
+			 * after the pattern, and '=' is on its separator list while the
+			 * first byte of the value is not. */
+			__xdata uint8_t *c = p + 8;	/* past "\nCookie:" */
+			while (*c && *c != '\r' && *c != '\n') {
+				if (is_word(c, "session")) {
+					session = c + 8;	/* past "session=" */
+					break;
+				}
+				c++;
+			}
+		}
 	}
 	if (content_type && is_word(content_type, "multipart/form-data; boundary")) {
 		dbg_string("\nFound multipart\n");

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -45,7 +45,7 @@ extern __xdata char sfp_module_model[2][17];
 extern __xdata char sfp_module_serial[2][17];
 extern __xdata uint8_t sfp_options[2];
 
-__code uint8_t * __code HTTP_RESPONCE_JSON = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n";
+__code uint8_t * __code HTTP_RESPONCE_JSON = "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n";
 __code uint8_t * __code HTTP_RESPONCE_TXT = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n";
 
 // Convert uint8_t to ascii HEX char push on html-buffer.


### PR DESCRIPTION
## Problem

Logging in from a real browser intermittently (or, with certain cookies, always) bounces back to the login page with "Wrong password!" even though the password is correct — while the same credentials always work via curl. Reproduced and debugged on a SWTGW218AS.

## Root cause

**Session cookie parsed from a fixed offset.** `scan_header()` read the session id at `Cookie:` header offset +17, assuming `session=` is the first and only cookie. Browsers keep stale cookies for a long time — e.g. an `admin` cookie left over from the switch's **vendor firmware** — so the header can arrive as `Cookie: admin=..; session=..`, the fixed offset then points into the `admin` value, authentication silently fails and every authenticated page redirects back to login (with a misleading "Wrong password!", since the redirect chain preserves the login referrer). curl sends only `session=`, which is why command-line tests passed while a real browser (with that stale cookie) failed.

## Changes

- `scan_header()`: scan the `Cookie:` header for the actual `session=` key instead of using a fixed offset (matched as `"session"` — `is_word()` requires a separator after the pattern and `=` is on its list).
- `is_word_x()`: accept `;` as a terminating separator so the session value also matches when it is not the last cookie in the header.
- All HTTP responses now include `Connection: close`. The httpd is built with `UIP_CONF_MAX_CONNECTIONS = 1` and never advertised that a connection is not persistent, so a browser could pool and reuse a connection the server had already closed. This is a general correctness fix independent of the cookie bug above.
- `login.html`: added `autocomplete="current-password"` so password managers recognise the field (kept the existing i18n/`style.css` structure unchanged — no regression to multi-language support).
- The file-serving CSP is now a complete first-party policy (`default-src 'self'; …`) instead of a lone `style-src`, which stopped privacy-shield browsers (Brave, NoScript) from injecting their own noisy report-only probes.

## Verification

On hardware (SWTGW218AS), end-to-end in a real browser **with the stale vendor `admin` cookie present**: login → `index.html`, all pages and JSON endpoints work. curl behaviour unchanged. `make MACHINE=SWTGW218AS` builds clean on this branch.