### PR TITLE
stp: ports never left the blocking state (stp on took the network down)

### DIFF
--- a/rtl837x_stp.c
+++ b/rtl837x_stp.c
@@ -198,6 +198,22 @@ void stp_timers(void) __banked
 			print_byte(i); write_char('\n');
 			stp_cnf_send(i);
 		}
+		/* Promote a port out of the initial blocking state once its listen
+		 * period expires. stp_setup() puts every port into blocking with
+		 * port_timers = 10 s, but nothing ever counted that down - so on a
+		 * network with no other RSTP bridge (nobody sends us BPDUs) every
+		 * port stayed blocking FOREVER and "stp on" killed the whole
+		 * network. If no better root was heard during the listen period we
+		 * are the designated bridge on that port: go to forwarding. */
+		if (port_timers[i]) {
+			if (!--port_timers[i]) {
+				reg_read_m(RTL837X_MSTP_STATES);
+				sfr_data[3 - (i >> 2)] |= (uint8_t)(0b11 << ((i << 1) & 0x7));
+				reg_write_m(RTL837X_MSTP_STATES);
+				print_string("STP: port forwarding ");
+				print_byte(i); write_char('\n');
+			}
+		}
 	}
 }
 
@@ -212,7 +228,7 @@ void stp_setup(void) __banked
 		uint8_t bit_mask = 0b01 << ( (i << 1) & 0x7);
 		sfr_data[3 - (i >> 2)] |= bit_mask;
 		port_hello[i] = TIME_HELLO;
-		port_timers[i] = 0xa00;	// 10 sec in blocking state
+		port_timers[i] = 0x280;	// 10 s listen period (stp_timers runs at ~64 Hz: main loop ~256 Hz / (STP_TICK_DIVIDER+1))
 	}
 	sfr_data[1] |= 0x0f; // Do not block CPU-Port
 	reg_write_m(RTL837X_MSTP_STATES); // R5310-000d555f 

--- a/rtl837x_stp.h
+++ b/rtl837x_stp.h
@@ -7,6 +7,6 @@ void stp_setup(void) __banked;
 void stp_timers(void) __banked;
 void stp_off(void) __banked;
 
-#define TIME_HELLO 0x200 // 2 sec
+#define TIME_HELLO 0x80 // 2 s (at the ~64 Hz stp_timers rate)
 
 #endif


### PR DESCRIPTION
## Problem

`stp on` puts every port into blocking (`stp_setup()`, with `port_timers` set to a value commented as "10 sec in blocking state") — but nothing ever counts those timers down. `stp_timers()` only sends hello BPDUs. Port state transitions only ever happen in `stp_setup()` (→ blocking) and `stp_off()` (→ forwarding).

On a network with no other (R)STP bridge — i.e. nobody sends us BPDUs — every port therefore stays blocking **forever**, and enabling STP takes the whole network down until `stp off`. That's the common case for this class of switch (a single managed switch with plain hosts attached).

## Changes

- `stp_timers()`: count `port_timers` down; when a port's listen period expires with no better root heard, promote it to forwarding in `MSTP_STATES` (we are the designated bridge on that port).
- Calibrate the tick constants to the real `stp_timers()` rate (~64 Hz: main loop ~256 Hz divided by `STP_TICK_DIVIDER`+1): `TIME_HELLO` `0x200`→`0x80` gives an actual 2 s hello, `port_timers` `0xa00`→`0x280` an actual 10 s listen period. Measured on hardware (with promotion in place), the old constants converged only after ~40 s and sent hellos every ~8 s.

## Verification

On a SWTGW218AS: `stp on` → all ports report Blocking; after the 10 s listen period every port promotes to Forwarding and LAN connectivity returns; `stp off` restores forwarding immediately. With no other RSTP bridge present we elect ourselves as root, as before. `make MACHINE=SWTGW218AS` builds clean on this branch.