### PR TITLE
Fix rate range for SDS_10GR return value

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1210,7 +1210,7 @@ static inline uint8_t sfp_rate_to_sds_config(register uint8_t rate)
 		return SDS_1000BX_FIBER;
 	if (rate >= 0x19 && rate <= 0x20)  // Ethernet 2.5 GBit
 		return SDS_HSG;
-	if (rate >= 0x63 && rate < 0x70)
+	if (rate >= 0x62 && rate < 0x70)
 		return SDS_10GR;
 	return 0xff;
 }


### PR DESCRIPTION
Broaden range of SFP+ rates mapped to SDS_10GR
A commonly used SFP+ form-factor 10GBase-LR (Hisense LTF1303-BH+) reports 0x62(BR Nominal: 9800MBd) at power on and then switches to 0x64 after booting up.

0x60 -> 9.6gbps
0x62 -> 9.8gbps
0x63 -> 9.9gbps
0x64 -> 10gbps
0x6f -> 11.1gbps
0x80 -> 12.8gbps

These are outside of the previous 0x63-0x6f range which prevented the link from ever being brought up. So I changed the range to 0x60-0x7f

The issue #292 