### PR TITLE
stp: contain BPDUs to the CPU while STP runs

### DIFF
--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -395,6 +395,48 @@ void port_l2_learned(void) __banked
 
 
 /*
+ * Static L2 multicast entry for the link-local group 01:80:C2:00:00:<mac_last>
+ * in VLAN `vid`, with member portmask `pmask` (bit 9 = CPU port).
+ *
+ * Slow-protocol frames (LACP, STP BPDUs) must reach the CPU without being
+ * flooded to other ports. The RMA "trap" action cannot deliver to the
+ * internal NIC on this hardware (its destination is an external CPU on a
+ * physical port), so the protocol modules keep the RMA action at "forward"
+ * and constrain the egress with this entry instead: the lookup hits the
+ * entry's portmask rather than the VLAN flood mask (hardware-verified with
+ * both the CPU bit cleared - delivery stops - and CPU-only - no egress).
+ *
+ * SMI layout (vendor SDK, L2-multicast entry variant):
+ *   DATA_IN_A = MAC bytes 5..2         -> c2 00 00 <mac_last>
+ *   DATA_IN_B = MAC[1..0] | vid<<16 | IVL<<29 | pmask[1:0]<<30
+ *   DATA_IN_C = pmask[9:2]
+ * Lookups are IVL (a VID-0 entry is not matched), so callers add one entry
+ * per PVID in use. The write command (table 4 = the whole L2 LUT) hashes
+ * MAC+VID and picks the bucket slot itself; TBL_EXECUTE self-clears.
+ * Overwriting the same MAC+VID replaces the entry, so a caller can retarget
+ * the mask at will (e.g. back to all ports to restore flooding).
+ */
+__xdata uint8_t l2mc_guard;	/* xdata: the internal-RAM overlay (OSEG) is full */
+
+void port_l2mc_set(uint8_t mac_last, __xdata uint16_t vid, __xdata uint16_t pmask) __banked
+{
+	l2mc_guard = 0;
+	do {	/* wait out any previous table op (bounded, cf. the IGMP guards) */
+		reg_read_m(RTL837X_TBL_CTRL);
+	} while ((sfr_data[3] & TBL_EXECUTE) && ++l2mc_guard);
+
+	REG_WRITE(RTL837x_TBL_DATA_IN_A, 0xc2, 0x00, 0x00, mac_last);
+	REG_WRITE(RTL837x_TBL_DATA_IN_B, 0x20 | (vid >> 8) | ((pmask & 0x3) << 6), vid, 0x01, 0x80);
+	REG_WRITE(RTL837x_TBL_DATA_IN_C, 0, 0, 0, pmask >> 2);
+	REG_WRITE(RTL837X_TBL_CTRL, 0, 0, TBL_L2_UNICAST, TBL_WRITE | TBL_EXECUTE);
+	l2mc_guard = 0;
+	do {
+		reg_read_m(RTL837X_TBL_CTRL);
+	} while ((sfr_data[3] & TBL_EXECUTE) && ++l2mc_guard);
+}
+
+
+/*
  * Basic L2 configuration such as time to forget an entry
  */
 void port_l2_setup(void) __banked

--- a/rtl837x_port.h
+++ b/rtl837x_port.h
@@ -54,6 +54,7 @@ void vlan_name_remove(uint16_t vlan) __banked;
 void vlan_setup(void) __banked;
 void port_pvid_set(uint8_t port, __xdata uint16_t pvid) __banked;
 uint16_t port_pvid_get(uint8_t port) __banked;
+void port_l2mc_set(uint8_t mac_last, __xdata uint16_t vid, __xdata uint16_t pmask) __banked;
 void vlan_create(void) __banked;
 void vlan_delete(uint16_t vlan) __banked;
 void vlan_dump(void) __banked;

--- a/rtl837x_stp.c
+++ b/rtl837x_stp.c
@@ -11,11 +11,18 @@
 #include "rtl837x_sfr.h"
 #include "rtl837x_regs.h"
 #include "rtl837x_stp.h"
+#include "rtl837x_port.h"	/* port_pvid_get(), port_l2mc_set() */
 #include "uip.h"
 #include "machine.h"
 
 extern __code struct machine machine;
 extern __xdata uint8_t sfr_data[4];
+extern __xdata struct machine_runtime machine_detected;	/* owned by rtl837x_port.c */
+
+/* Scratch for stp_fdb_update(), in xdata: plain locals would overflow the
+ * near-full internal-RAM overlay (OSEG), cf. rtl837x_lacp.c. */
+__xdata uint16_t stp_fdb_vid;
+__xdata uint8_t  stp_fdb_i;
 
 extern __xdata struct uip_eth_addr uip_ethaddr;
 
@@ -202,6 +209,39 @@ void stp_timers(void) __banked
 }
 
 
+/*
+ * Steer BPDUs (01:80:C2:00:00:00) while STP runs: one static CPU-only L2
+ * multicast entry per PVID in use, so BPDUs reach the CPU without being
+ * flooded to other ports (a bridge running STP must consume BPDUs, not
+ * relay them - relaying poisons the neighbours' view of the topology).
+ *
+ * With STP off the same entries are retargeted to all ports + CPU, which
+ * restores the previous flood behaviour ("BPDU transparency"): the
+ * surrounding spanning tree can keep spanning *through* this switch, which
+ * unmanaged setups rely on. Same per-PVID/IVL rules as the LACP steering -
+ * see port_l2mc_set() and rtl837x_lacp.c. NOTE: changing a port's PVID
+ * while STP runs needs `stp off`/`on` to refresh the entries.
+ */
+static void stp_fdb_update(__xdata uint16_t pmask)
+{
+	/* Unlike LACPDUs (always untagged, so per-PVID entries suffice), BPDUs
+	 * can arrive VLAN-tagged and then classify into the tag's VID - cover
+	 * every VLAN that exists in the VLAN table, plus every port's PVID for
+	 * the untagged case. A duplicate VID just overwrites the same slot. */
+	for (stp_fdb_vid = 1; stp_fdb_vid < 4095; stp_fdb_vid++) {
+		if (vlan_get(stp_fdb_vid) < 0)
+			continue;
+		if (!(sfr_data[0] & 0x02))	/* bit 1: VLAN table entry valid */
+			continue;
+		port_l2mc_set(0x00, stp_fdb_vid, pmask);
+	}
+	for (stp_fdb_i = machine.min_port; stp_fdb_i <= machine.max_port; stp_fdb_i++) {
+		stp_fdb_vid = port_pvid_get(stp_fdb_i);
+		port_l2mc_set(0x00, stp_fdb_vid, pmask);
+	}
+}
+
+
 void stp_setup(void) __banked
 {
 	print_string("Enabling STP: ");
@@ -222,6 +262,9 @@ void stp_setup(void) __banked
 	root_bridge.prio = 0x80; // This corresponds to 32768
 	root_bridge.ext	= 0x00;
 	memcpy(root_bridge.mac, uip_ethaddr.addr, 6);
+
+	/* Take BPDUs to the CPU only - we are a participating bridge now. */
+	stp_fdb_update(PMASK_CPU);
 }
 
 
@@ -236,4 +279,7 @@ void stp_off(void) __banked
 	}
 	sfr_data[1] |= 0x0f; // Do not block CPU-Port
 	reg_write_m(RTL837X_MSTP_STATES);
+
+	/* Restore BPDU transparency: flood them again like an unmanaged switch. */
+	stp_fdb_update(PMASK_CPU | (machine_detected.isRTL8373 ? PMASK_9 : PMASK_6));
 }


### PR DESCRIPTION
With STP enabled the switch participates in the spanning tree, so BPDUs must be consumed by the bridge, not relayed — yet `01:80:C2:00:00:00` was flooded across the VLAN like any multicast, so every BPDU leaked to all other ports. This is the same defect class as the LACPDU flood being addressed in #299, applied to the BPDU group.

**Mechanism.** The RMA "trap" action cannot deliver to the internal NIC on this hardware (its trap destination is an external CPU on a physical port — this board has none), so the working delivery is RMA *forward* constrained by a **static L2 multicast entry with a CPU-only member mask**: the forward lookup hits the entry's portmask instead of the VLAN flood mask. Hardware-verified in both directions on a SWTGW218AS (a mask without the CPU bit stops delivery, a CPU-only mask delivers with no port egress). The first commit adds the shared `port_l2mc_set()` helper; #299 adopts it for LACPDUs as a follow-up once either lands.

**Per-VLAN entries.** BPDUs can arrive VLAN-tagged and classify into the tag's VID (lookups are IVL), so `stp on` writes one CPU-only entry per VLAN present in the VLAN table, plus each port's PVID for the untagged case.

**`stp off` restores transparency.** The entries are retargeted to all ports + CPU, restoring the previous flood behaviour: with STP disabled an unmanaged-style switch is expected to be transparent to BPDUs so a surrounding spanning tree can span through it (topologies genuinely rely on this), and dropping them instead would partition that tree.

Known pre-existing interaction (unchanged here, noted in the commit): with STP enabled all ports start out blocking, which also stops egress of CPU-originated LACPDUs, so an active LACP aggregate drops until the ports reach forwarding.

Tested on SWTGW218AS: entries created per VLAN on `stp on` and retargeted on `stp off` (visible in the L2 page with #299's listing fix), enable/disable fully reversible across cold boots.
