### PR TITLE
makefile: Make CC and ASM overridable via command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ DEFAULT_CONFIG_LOCATION = 454656
 CONFIG_LOCATION = 458752
 HTML_LOCATION = 262144
 
-CC = sdcc
+CC ?= sdcc
 CC_FLAGS = -mmcs51 -I. -Ihttpd -Iuip
-ASM = sdas8051
+ASM ?= sdas8051
 AFLAGS= -plosgff
 
 SUBDIRS := tools

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,40 @@ create_build_dir:
 	mkdir -p $(BUILDDIR)/uip
 	mkdir -p $(BUILDDIR)/httpd
 
-SRCS = rtlplayground.c rtl837x_flash.c rtl837x_leds.c rtl837x_phy.c rtl837x_port.c cmd_parser.c html_data.c rtl837x_igmp.c
-SRCS += rtl837x_stp.c rtl837x_pins.c dhcp.c machine.c cmd_editor.c rtl837x_bandwidth.c rtl837x_init.c syslog.c
-SRCS += uip/timer.c uip/uip.c uip/uip_arp.c uip/uiplib.c uip/uip-fw.c uip/uip-neighbor.c uip/uip-split.c udp_apps.c
-SRCS += httpd/httpd.c httpd/page_impl.c
+# Keep machine.c in first position to fail immediately on invalid $MACHINE value
+SRCS = \
+	machine.c \
+	cmd_editor.c \
+	cmd_parser.c \
+	dhcp.c \
+	html_data.c \
+	rtlplayground.c \
+	syslog.c \
+	udp_apps.c
+
+# RTL837x
+SRCS += \
+	rtl837x_bandwidth.c \
+	rtl837x_flash.c \
+	rtl837x_igmp.c \
+	rtl837x_init.c \
+	rtl837x_leds.c \
+	rtl837x_phy.c \
+	rtl837x_pins.c\
+	rtl837x_port.c \
+	rtl837x_stp.c
+SRCS += \
+	httpd/httpd.c \
+	httpd/page_impl.c
+SRCS += \
+	uip/timer.c \
+	uip/uip.c \
+	uip/uiplib.c \
+	uip/uip_arp.c \
+	uip/uip-fw.c \
+	uip/uip-neighbor.c \
+	uip/uip-split.c
+
 OBJS = ${SRCS:%.c=$(BUILDDIR)/%.rel}
 DEPS := ${SRCS:%.c=$(BUILDDIR)/%.d}
 HTML := $(shell find $(html) -name '*.js' -or -name '*.html' -or -name '*.svg')

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ DEFAULT_CONFIG_LOCATION = 454656
 CONFIG_LOCATION = 458752
 HTML_LOCATION = 262144
 
-CC ?= sdcc
+ifeq ($(origin CC),default)
+CC = sdcc
+endif
 CC_FLAGS = -mmcs51 -I. -Ihttpd -Iuip
 ASM ?= sdas8051
 AFLAGS= -plosgff

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ FILENAME_EXTENSION = $(VERSION_EXTENSION)-$(MACHINE)
 all: create_build_dir $(VERSION_HEADER) $(SUBDIRS) $(BUILDDIR)/rtlplayground-$(FILENAME_EXTENSION).bin
 
 create_build_dir:
-	mkdir -p $(BUILDDIR)
-	mkdir -p $(BUILDDIR)/uip
-	mkdir -p $(BUILDDIR)/httpd
+	mkdir -p "$(BUILDDIR)"
+	mkdir -p "$(BUILDDIR)/uip"
+	mkdir -p "$(BUILDDIR)/httpd"
 
 # Keep machine.c in first position to fail immediately on invalid $MACHINE value
 SRCS = \


### PR DESCRIPTION
This makes it easier to run make without docker within distros without editing Makefile. For example Fedora: `ASM=sdcc-sdas8051 CC=sdcc-sdcc make`

Ideally I would like to make `MACHINE` overridable from commandline as well...