### PR TITLE
Sram hunting

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -165,7 +165,7 @@ bool is_url_word_x(__xdata uint8_t *uri_str_p, __xdata uint8_t *src_str_p)
 }
 
 
-bool is_word_x(__xdata uint8_t *lhs_str_p, __xdata uint8_t *rhs_str_p)
+bool is_word_x(__xdata uint8_t * lhs_str_p, __xdata uint8_t * rhs_str_p)
 {
 	uint8_t u, c;
 
@@ -241,7 +241,7 @@ __xdata uint8_t *skip_boundary(__xdata uint8_t *p)
 }
 
 
-__xdata uint8_t *scan_header(__xdata uint8_t *p)
+__xdata uint8_t *scan_header(__xdata uint8_t * __xdata p)
 {
 	content_type = 0;
 	session = 0;

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -41,8 +41,8 @@ __xdata uint32_t cont_addr;
 
 // HTTP header properties
 __xdata uint8_t boundary[72];
-__xdata uint8_t *content_type = 0;
-__xdata uint8_t *session = 0;
+__xdata uint8_t * __xdata content_type;
+__xdata uint8_t * __xdata session;
 
 // Global variables holding POST state
 __xdata uint16_t bindex; // Current index into the boundary
@@ -54,7 +54,7 @@ __xdata char passwd[21];
 __xdata char session_id[SESSION_ID_LENGTH + 1];
 __xdata uint8_t authenticated;
 __xdata uint32_t now;
-__xdata uint8_t *timeptr;
+__xdata uint8_t * __xdata timeptr;
 __xdata uint32_t last_session_use;
 
 #define TSTATE_NONE		0
@@ -69,7 +69,7 @@ __xdata uint16_t crc_final;
 void crc16(__xdata uint8_t *v) __naked;
 
 
-inline uint8_t is_separator(uint8_t c)
+inline bool is_separator(uint8_t c)
 {
 	return c == ' ' || c == '\t' || c == '?' || c == '=';
 }
@@ -300,7 +300,7 @@ __xdata uint8_t *scan_header(__xdata uint8_t *p)
 }
 
 
-void gen_random_bytes(__xdata uint8_t *b, uint8_t bytes)
+void gen_random_bytes(__xdata uint8_t *b, register uint8_t bytes)
 {
 	__xdata uint8_t i = 0;
 	while (bytes) {

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -299,10 +299,12 @@ __xdata uint8_t *scan_header(__xdata uint8_t *p)
 	return p;
 }
 
-
-void gen_random_bytes(__xdata uint8_t *b, register uint8_t bytes)
+/* 
+ * Generate random HEX-chars at the buffer location.
+*/
+void gen_random_hex_chars(__xdata uint8_t * b, __xdata uint8_t bytes)
 {
-	__xdata uint8_t i = 0;
+	uint8_t i = 0;
 	while (bytes) {
 		if (!i)
 			get_random_32();
@@ -480,7 +482,7 @@ void handle_post(void)
 		if (is_url_word_x(p, passwd)) {
 			dbg_string("Password accepted!\n");
 			read_reg_timer(&last_session_use);
-			gen_random_bytes(session_id, SESSION_ID_LENGTH);
+			gen_random_hex_chars(session_id, SESSION_ID_LENGTH);
 			session_id[SESSION_ID_LENGTH] = '\0';
 			slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nConnection: close\r\nLocation: index.html\r\n" \
 					      "Set-Cookie: session=");

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -185,22 +185,24 @@ void send_sfp_info(uint8_t sfp)
 	}
 }
 
+__xdata uint8_t sfp;
+__xdata uint8_t sfp_len;
 
-void sfp_send_data(uint8_t slot, uint8_t reg, uint8_t len)
+void sfp_send_data(uint8_t reg)
 {
 	// maximum supported transfer size is 16 bytes
-	if (len > 16)
+	if (sfp_len > 16)
 		return;
 
 	if (reg & 0x80) {	// Configure SFP readings address (0x51) as I2C device address
 		reg &= 0x7f;
-		REG_WRITE(RTL837X_REG_I2C_CTRL, 0x00, 0x1 << (I2C_MEM_ADDR_WIDTH-16) | (len - 1) & 0xf,  0x51 >> 5, (0x51 << 3) & 0xff);
+		REG_WRITE(RTL837X_REG_I2C_CTRL, 0x00, 0x1 << (I2C_MEM_ADDR_WIDTH-16) | (sfp_len - 1) & 0xf,  0x51 >> 5, (0x51 << 3) & 0xff);
 	} else {
-		REG_WRITE(RTL837X_REG_I2C_CTRL, 0x00, 0x1 << (I2C_MEM_ADDR_WIDTH-16) | (len - 1) & 0xf,  0x50 >> 5, (0x50 << 3) & 0xff);
+		REG_WRITE(RTL837X_REG_I2C_CTRL, 0x00, 0x1 << (I2C_MEM_ADDR_WIDTH-16) | (sfp_len - 1) & 0xf,  0x50 >> 5, (0x50 << 3) & 0xff);
 	}
 
 	reg_read_m(RTL837X_REG_I2C_CTRL);
-	sfr_mask_data(1, 0xfc, i2c_bus_from_scl_pin(machine.sfp_port[slot].i2c.scl) << 5 | i2c_bus_from_sda_pin(machine.sfp_port[slot].i2c.sda) << 2);
+	sfr_mask_data(1, 0xfc, i2c_bus_from_scl_pin(machine.sfp_port[sfp].i2c.scl) << 5 | i2c_bus_from_sda_pin(machine.sfp_port[sfp].i2c.sda) << 2);
 	reg_write_m(RTL837X_REG_I2C_CTRL);
 
 	REG_WRITE(RTL837X_REG_I2C_IN, 0, 0, 0, reg);
@@ -213,7 +215,7 @@ void sfp_send_data(uint8_t slot, uint8_t reg, uint8_t len)
 		reg_read_m(RTL837X_REG_I2C_CTRL);
 	} while (sfr_data[3] & 0x1);
 
-	for (uint8_t i = 0; i < len; i++) {
+	for (uint8_t i = 0; i < sfp_len; i++) {
 		if (!(i & 0x3))
 			reg_read_m(RTL837X_REG_I2C_OUT + i);
 		byte_to_html(sfr_data[3 - (i & 0x3)]);
@@ -666,48 +668,49 @@ void send_status(void)
 		slen += strtox(outbuf + slen, "\"");
 
 		if (machine.is_sfp[i]) {
-			uint8_t sfp = machine.is_sfp[i] - 1;
+			sfp = machine.is_sfp[i] - 1;
 			slen += strtox(outbuf + slen, ",\"isSFP\":1,\"enabled\":");
 			if (!(sfp_pins_last & (0x1 << (sfp << 2)))) {
-				bool_to_html(1);
-				slen += strtox(outbuf + slen,",\"sfp_options\":\"0x");
+				slen += strtox(outbuf + slen,"1,\"sfp_options\":\"0x");
 				byte_to_html(sfp_options[sfp]);
 				if (sfp_options[sfp] & 0x40) {
+					sfp_len = 2;
 					slen += strtox(outbuf + slen,"\",\"sfp_temp\":\"0x");
-					sfp_send_data(sfp, 224, 2);
+					sfp_send_data(224);
 					slen += strtox(outbuf + slen,"\",\"sfp_vcc\":\"0x");
-					sfp_send_data(sfp, 226, 2);
+					sfp_send_data(226);
 					slen += strtox(outbuf + slen,"\",\"sfp_txbias\":\"0x");
-					sfp_send_data(sfp, 228, 2);
+					sfp_send_data(228);
 					slen += strtox(outbuf + slen,"\",\"sfp_txpower\":\"0x");
-					sfp_send_data(sfp, 230, 2);
+					sfp_send_data(230);
 					slen += strtox(outbuf + slen,"\",\"sfp_rxpower\":\"0x");
-					sfp_send_data(sfp, 232, 2);
+					sfp_send_data(232);
 					if (sfp_options[sfp] & 0x10) {
+						sfp_len = 4;
 						slen += strtox(outbuf + slen,"\",\"sfp_temp_cal\":\"0x");
-						sfp_send_data(sfp, 212, 4);
+						sfp_send_data(212);
 						slen += strtox(outbuf + slen,"\",\"sfp_vcc_cal\":\"0x");
-						sfp_send_data(sfp, 216, 4);
+						sfp_send_data(216);
 						slen += strtox(outbuf + slen,"\",\"sfp_txbias_cal\":\"0x");
-						sfp_send_data(sfp, 204, 4);
+						sfp_send_data(204);
 						slen += strtox(outbuf + slen,"\",\"sfp_txpower_cal\":\"0x");
-						sfp_send_data(sfp, 208, 4);
+						sfp_send_data(208);
 						slen += strtox(outbuf + slen,"\",\"sfp_rxpower_cal\":\"0x");
-						sfp_send_data(sfp, 184, 16);
-						sfp_send_data(sfp, 200, 4);
+						sfp_len = 16;
+						sfp_send_data(184);
+						sfp_len = 4;
+						sfp_send_data(200);
 					}
 					slen += strtox(outbuf + slen,"\",\"sfp_state\":\"0x");
-					sfp_send_data(sfp, 238, 1);
+					sfp_len = 1;
+					sfp_send_data(238);
 				}
 				slen += strtox(outbuf + slen,"\",\"sfp_vendor\":\"");
-				for (register uint8_t s = 0; s < 16 && sfp_module_vendor[sfp][s]; s++)
-					outbuf[slen++] = sfp_module_vendor[sfp][s];
+				slen += xstrtox(outbuf + slen, &sfp_module_vendor[sfp], 16);
 				slen += strtox(outbuf + slen,"\",\"sfp_model\":\"");
-				for (register uint8_t s = 0; s < 16 && sfp_module_model[sfp][s]; s++)
-					outbuf[slen++] = sfp_module_model[sfp][s];
+				slen += xstrtox(outbuf + slen, &sfp_module_model[sfp], 16);
 				slen += strtox(outbuf + slen,"\",\"sfp_serial\":\"");
-				for (register uint8_t s = 0; s < 16 && sfp_module_serial[sfp][s]; s++)
-					outbuf[slen++] = sfp_module_serial[sfp][s];
+				slen += xstrtox(outbuf + slen, &sfp_module_serial[sfp], 16);
 				slen += strtox(outbuf + slen,"\",\"sfp_los\":");
 				if (machine.sfp_port[sfp].pin_los == GPIO_NA) {
 					slen += strtox(outbuf + slen,"null");

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -284,19 +284,25 @@ void send_vlan(uint16_t vlan)
 	vlan_get(vlan);
 	sfr_data_to_html();
 	slen += strtox(outbuf + slen, "\",\"name\":\"");
-	__xdata uint16_t n = vlan_name(vlan);
-	if (n== 0xffff) {
+	uint16_t n = vlan_name(vlan);
+	if (n == 0xffff) {
 		dbg_string("VLAN has no name\n");
 	} else {
-		while(vlan_names[n] && vlan_names[n] != ' ')
-			char_to_html(vlan_names[n++]);
+		uint8_t * vn = &vlan_names[n];
+		while(1) {
+			uint8_t c = *vn++;
+			if (c == '\0' || c == ' ') {
+				break;
+			}
+			char_to_html(c);
+		}
 	}
 	slen += strtox(outbuf + slen, "\",\"pvid\":\"0x");
-	uint16_t pvid_mask = 0;
+	__xdata uint16_t pvid_mask = 0;
 	for (uint8_t i = machine.min_port; i <= machine.max_port; i++) {
 		if (port_pvid_get(i) == vlan)
 			pvid_mask |= (1 << i);
-}
+	}
 	byte_to_html(pvid_mask >> 8);
 	byte_to_html(pvid_mask);
 	slen += strtox(outbuf + slen, "\"}");

--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -154,6 +154,8 @@ void reset_chip(void);
 void memcpy(__xdata void * __xdata dst, __xdata const void * __xdata src, uint16_t len);
 void memcpyc(register __xdata uint8_t *dst, register __code uint8_t *src, register uint16_t len);
 void memset(register __xdata uint8_t *dst, register __xdata uint8_t v, register uint8_t len);
+bool memcmp(__xdata uint8_t *dst, __xdata uint8_t *src, uint8_t len);
+bool is_mem_zero(__xdata uint8_t *src, uint8_t len);
 uint16_t strlen(register __code const char *s);
 uint16_t strlen_x(register __xdata const char *s);
 uint16_t strtox(register __xdata uint8_t *dst, register __code const char *s);

--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -157,6 +157,7 @@ void memset(register __xdata uint8_t *dst, register __xdata uint8_t v, register 
 uint16_t strlen(register __code const char *s);
 uint16_t strlen_x(register __xdata const char *s);
 uint16_t strtox(register __xdata uint8_t *dst, register __code const char *s);
+uint8_t xstrtox(__xdata uint8_t *dst, __xdata const char *s, uint8_t len);
 uint16_t strcpy(register __xdata uint8_t *dst, register const char *s);
 char strcmp(register __xdata const uint8_t *a, register __code const uint8_t *b);
 void tcpip_output(void);

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -307,6 +307,21 @@ void memcpyc(register __xdata uint8_t *dst, register __code uint8_t *src, regist
 		*dst++ = *src++;
 }
 
+bool memcmp(__xdata uint8_t *dst, __xdata uint8_t *src, uint8_t len)
+{
+	uint8_t ret = 0;
+	while (len--)
+		ret |= *dst++ ^ *src++;
+	return ret == 0;
+}
+
+bool is_mem_zero(__xdata uint8_t *src, uint8_t len) {
+	uint8_t ret = 0;
+    for (uint8_t c = 0; c < len; c++) {
+        ret |= *src++;
+    }
+	return ret == 0;
+}
 
 void memset(register __xdata uint8_t *dst, register __xdata uint8_t v, register uint8_t len)
 {

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -314,13 +314,27 @@ void memset(register __xdata uint8_t *dst, register __xdata uint8_t v, register 
 		*dst++ = v;
 }
 
-uint16_t strtox(register __xdata uint8_t *dst, register __code const char *s)
+uint16_t strtox(__xdata uint8_t *dst, __code const char *s)
 {
-	__xdata uint8_t *b = dst;
+	__xdata uint8_t * __xdata b = dst;
 	while (*s)
 		*dst++ = *s++;
 	*dst = 0;
 	return dst - b;
+}
+
+uint8_t xstrtox(__xdata uint8_t *dst, __xdata const char *s, uint8_t len)
+{
+	uint8_t i;
+	for (i = 0; i < len; i++) {
+		uint8_t c = *s++;
+		if (c == '\0') {
+			break;
+		}
+		*dst++ = c;
+	}
+	*dst = 0;
+	return i;
 }
 
 

--- a/syslog.c
+++ b/syslog.c
@@ -62,19 +62,19 @@ void syslog_callback(uint16_t lport) __banked
 
 	if ((state.readptr != state.writeptr) && state.line_available)
 	{
-		int16_t log_size = state.writeptr - state.readptr;
+		__xdata int16_t log_size = state.writeptr - state.readptr;
 		if (log_size < 0)
 			log_size += LOGBUF_SIZE;
 		
 		// Skipping linefeeds at the start of the log line
-		uint16_t log_start = state.readptr;
+		__xdata uint16_t log_start = state.readptr;
 		while (log_size > 0 && logbuf[log_start] == '\n') {
 			log_start = (log_start + 1) & (LOGBUF_SIZE - 1);
 			log_size--;
 		}
 
 		// Skipping linefeeds and whitespaces at the end of the log line
-		uint16_t log_end = state.writeptr;
+		__xdata uint16_t log_end = state.writeptr;
 		while ( (log_size > 0) && 
 				((logbuf[(log_end-1) & (LOGBUF_SIZE - 1)] == '\n') ||
 				 (logbuf[(log_end-1) & (LOGBUF_SIZE - 1)] == ' ')))
@@ -95,7 +95,7 @@ void syslog_callback(uint16_t lport) __banked
 			memcpy(SYSLOG_P + 4, logbuf + log_start, LOGBUF_SIZE - log_start);
 			memcpy(SYSLOG_P + 4 + LOGBUF_SIZE - log_start, logbuf, log_end);
 		} else {
-			 memcpy(SYSLOG_P + 4, logbuf + log_start, log_end - log_start);
+			memcpy(SYSLOG_P + 4, logbuf + log_start, log_end - log_start);
 		}
 
 		uip_udp_send(log_size+4);

--- a/uip/uip-fw.c
+++ b/uip/uip-fw.c
@@ -286,14 +286,11 @@ time_exceeded(void)
 static void
 fwcache_register(void)
 {
-  __xdata struct fwcache_entry *fw;
-  __xdata uint16_t i, oldest;
+  __xdata struct fwcache_entry * __xdata fw = NULL;
+  __xdata uint16_t oldest = FW_TIME;
 
-  oldest = FW_TIME;
-  fw = NULL;
-  
   /* Find the oldest entry in the cache. */
-  for(i = 0; i < FWCACHE_SIZE; ++i) {
+  for(__xdata uint16_t i = 0; i < FWCACHE_SIZE; ++i) {
     if(fwcache[i].timer == 0) {
       fw = &fwcache[i];
       break;
@@ -410,7 +407,7 @@ uip_fw_output(void)
 u8_t
 uip_fw_forward(void)
 {
-  __xdata struct fwcache_entry *fw;
+  __xdata struct fwcache_entry * __xdata fw;
 
   /* First check if the packet is destined for ourselves and return 0
      to indicate that the packet should be processed locally. */
@@ -432,7 +429,9 @@ uip_fw_forward(void)
   /* Check if the packet is in the forwarding cache already, and if so
      we drop it. */
 
-  for(fw = fwcache; fw < &fwcache[FWCACHE_SIZE]; ++fw) {
+  for(uint8_t i = 0; i < FWCACHE_SIZE; i++) {
+    fw = &fwcache[i];
+
     if(fw->timer != 0 &&
 #if UIP_REASSEMBLY > 0
        fw->len == BUF->len &&

--- a/uip/uip-neighbor.c
+++ b/uip/uip-neighbor.c
@@ -85,7 +85,7 @@ uip_neighbor_periodic(void)
 }
 /*---------------------------------------------------------------------------*/
 void
-uip_neighbor_add(__xdata uip_ipaddr_t ipaddr, __xdata struct uip_neighbor_addr *addr)
+uip_neighbor_add(__xdata uip_ipaddr_t ipaddr, __xdata struct uip_neighbor_addr * __xdata addr)
 {
   uint16_t i, oldest;
   u8_t oldest_time;

--- a/uip/uip-neighbor.h
+++ b/uip/uip-neighbor.h
@@ -54,7 +54,7 @@ struct uip_neighbor_addr {
 };
 
 void uip_neighbor_init(void);
-void uip_neighbor_add(__xdata uip_ipaddr_t ipaddr, __xdata struct uip_neighbor_addr *addr);
+void uip_neighbor_add(__xdata uip_ipaddr_t ipaddr, __xdata struct uip_neighbor_addr * __xdata addr);
 void uip_neighbor_update(__xdata uip_ipaddr_t ipaddr);
 __xdata struct uip_neighbor_addr *uip_neighbor_lookup(__xdata uip_ipaddr_t ipaddr);
 void uip_neighbor_periodic(void);

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -157,7 +157,7 @@ __xdata u16_t uip_len, uip_slen;
 __xdata u8_t uip_flags;     /* The uip_flags variable is used for
 				communication between the TCP/IP stack
 				and the application program. */
-__xdata struct uip_conn *uip_conn;   /* uip_conn always points to the current
+__xdata struct uip_conn * __xdata uip_conn;   /* uip_conn always points to the current
 				connection. */
 
 __xdata struct uip_conn uip_conns[UIP_CONNS];
@@ -167,7 +167,7 @@ __xdata u16_t uip_listenports[UIP_LISTENPORTS];
                              /* The uip_listenports list all currently
 				listning ports. */
 #if UIP_UDP
-__xdata struct uip_udp_conn *uip_udp_conn;
+__xdata struct uip_udp_conn * __xdata uip_udp_conn;
 __xdata struct uip_udp_conn uip_udp_conns[UIP_UDP_CONNS];
 #endif /* UIP_UDP */
 
@@ -466,7 +466,7 @@ uip_connect(register __xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banke
 /*---------------------------------------------------------------------------*/
 #if UIP_UDP
 __xdata struct uip_udp_conn *
-uip_udp_new(__xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banked
+uip_udp_new(__xdata uip_ipaddr_t * __xdata ripaddr, __xdata u16_t rport) __banked
 {
   __xdata struct uip_udp_conn *conn;
   

--- a/uip/uip.h
+++ b/uip/uip.h
@@ -763,7 +763,7 @@ void uip_send(__xdata const void *data, __xdata uint16_t len) __banked;
  * \return The uip_udp_conn structure for the new connection or NULL
  * if no connection could be allocated.
  */
-__xdata struct uip_udp_conn *uip_udp_new(__xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banked;
+__xdata struct uip_udp_conn *uip_udp_new(__xdata uip_ipaddr_t * __xdata ripaddr, __xdata u16_t rport) __banked;
 
 /**
  * Removed a UDP connection.
@@ -1193,7 +1193,7 @@ struct uip_conn {
  * The uip_conn pointer can be used to access the current TCP
  * connection.
  */
-extern __xdata struct uip_conn *uip_conn;
+extern __xdata struct uip_conn * __xdata uip_conn;
 /* The array containing all uIP connections. */
 extern __xdata struct uip_conn uip_conns[UIP_CONNS];
 /**
@@ -1226,7 +1226,7 @@ struct uip_udp_conn {
 /**
  * The current UDP connection.
  */
-extern __xdata struct uip_udp_conn *uip_udp_conn;
+extern __xdata struct uip_udp_conn * __xdata uip_udp_conn;
 extern __xdata struct uip_udp_conn uip_udp_conns[UIP_UDP_CONNS];
 #endif /* UIP_UDP */
 

--- a/uip/uip_arp.c
+++ b/uip/uip_arp.c
@@ -175,18 +175,18 @@ uip_arp_timer(void) __banked
 }
 /*-----------------------------------------------------------------------------------*/
 static void
-uip_arp_update(__xdata u16_t *ipaddr, __xdata struct uip_eth_addr *ethaddr)
+uip_arp_update(__xdata u16_t * __xdata ipaddr, __xdata struct uip_eth_addr * __xdata ethaddr)
 {
-  uint8_t i;
+  __xdata uint8_t i;
   /* Walk through the ARP mapping table and try to find an entry to
      update. If none is found, the IP -> MAC address mapping is
      inserted in the ARP table. */
   for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
     /* Only check those entries that are actually in use. */
-    if(arp_table[i].ipaddr[0] != 0 && arp_table[i].ipaddr[1] != 0) {
+    if(!is_mem_zero(arp_table[i].ipaddr, 4)) {
       /* Check if the source IP address of the incoming packet matches
          the IP address in this ARP table entry. */
-      if(ipaddr[0] == arp_table[i].ipaddr[0] && ipaddr[1] == arp_table[i].ipaddr[1]) {
+      if(memcmp(arp_table[i].ipaddr, ipaddr, 4)) {
 	/* An old entry found, update this and return. */
 	memcpy(arp_table[i].ethaddr.addr, ethaddr->addr, 6);
 	arp_table[i].time = arptime;
@@ -201,7 +201,7 @@ uip_arp_update(__xdata u16_t *ipaddr, __xdata struct uip_eth_addr *ethaddr)
 
   /* First, we try to find an unused entry in the ARP table. */
   for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
-    if(arp_table[i].ipaddr[0] == 0 && arp_table[i].ipaddr[1] == 0)
+    if(is_mem_zero(arp_table[i].ipaddr, 4))
       break;
   }
 


### PR DESCRIPTION
I am hunting for SRAM bytes.

I am looking in every generated `output/*.asm` to see what is using SRAM.
Looking for section
```
;--------------------------------------------------------
; internal ram data
;--------------------------------------------------------
```

1. Some are easy fixes. Like static pointer that is not declared to put in `XDATA`.
2. But other are by the compiler that allocates SRAM forever, for function that are only called once at boottime.
3. Deadstore, the compiler stores a bool flag, but never reads it back because that part is already optimized out. (found at-least 3 placed and bytes).
4. a fix SRAM byte is used for only one function to pass a argument. Easy fix is just add `__xdata` in the front. Although that is not ideal, I am not sure why SDCC is doing that.
5. added multiple 32-bit values needed more sram.

Still work in progress but I want it to share it already.

Current progress: 31 bytes of SRAM freed.
Baseline code: c86d4b31f2c7c0c5258e8797868cc62e69b05b89 vs this PR.

```patch
< 0x10:|b|b|b|b|b|b|b|b|b|b|b|c|c|c|c|k|
< 0x20:|B|B|T|d|d|e|e|e|e|e|e|e|e|e|e|e|
< 0x30:|e|e|e|e|e|e|e|e|e|e|e|e|e|e|e|e|
< 0x40:|e|e|f|f|f|f|f|g|g|g|g|g|g|g|g|g|
< 0x50:|g|g|g|g|g|g|h|h|h|h|h|h|h|h|h|h|
< 0x60:|i|i|i|i|i|i|i|i|i|j|j|j|j|j|j|j|
< 0x70:|j|j|j|j|j|Q|Q|Q|Q|Q|Q|Q|Q|S|S|S|
---
> 0x10:|b|b|b|b|b|b|b|b|b|b|b|c|c|h| | |
> 0x20:|B|B|T|d|d|d|d|d|d|d|d|d|d|d|d|d|
> 0x30:|d|d|d|d|d|d|d|d|d|d|d|e|e|e|e|e|
> 0x40:|e|e|e|e|f|f|f|f|f|f|f|f|g|g|g|g|
> 0x50:|g|g|g|g|g|g|Q|Q|Q|Q|Q|Q|Q|Q|S|S|
> 0x60:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
> 0x70:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
21,22c21,22
< 16 bit mode initial stack starts at: 0x7d (sp set to 0x7c) with 131 bytes available.
< No spare internal RAM space left.
---
> 16 bit mode initial stack starts at: 0x5e (sp set to 0x5d) with 162 bytes available.
> The largest spare internal RAM space starts at 0x1e with 2 bytes available.
28,29c28,29
<    EXTERNAL RAM     0x0001   0x27c7   10183    16777216
<    ROM/EPROM/FLASH  0x0000   0x2d2fc  94666    16777216
---
>    EXTERNAL RAM     0x0001   0x27ea   10218    16777216
>    ROM/EPROM/FLASH  0x0000   0x2d32a  95117    16777216
```

