### PR TITLE
Reject VLAN IDs and numeric arguments the hardware cannot take

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -736,8 +736,7 @@ void parse_mtu(void)
 		print_string("mtu [port] [size]\n");
 		return;
 	}
-	atoi_short(&mtu, cmd_words_b[2]);
-	if (mtu < 64 || mtu > 0x3fff) {
+	if (atoi_short(&mtu, cmd_words_b[2]) || mtu < 64 || mtu > 0x3fff) {
 		print_string("MTU must be 64..16383\n");
 		return;
 	}

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -347,6 +347,8 @@ void parse_vlan(void)
 			return;
 		}
 		if (cmd_compare(2, "mgmt")) {
+			if (vlan_settings.vlan > 4094)
+				goto err;
 			management_vlan = vlan_settings.vlan;
 			if (!vlan_settings.vlan)
 				print_string("Management VLAN disabled\n");

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -191,8 +191,11 @@ uint8_t atoi_byte(__xdata uint8_t *out, uint8_t idx)
 	uint8_t num = 0;
 
 	while (isnumber(cmd_buffer[idx])) {
+		uint8_t val = cmd_buffer[idx] - '0';
 		err = 0;
-		num = (num * 10) + cmd_buffer[idx] - '0';
+		if (num > 25 || (num == 25 && val > 5))
+			return 1;
+		num = (num * 10) + val;
 		idx++;
 	}
 
@@ -209,6 +212,8 @@ uint8_t atoi_short(__xdata uint16_t *vlan, uint8_t idx)
 	while (isnumber(cmd_buffer[idx])) {
 		err = 0;
 		uint8_t val = cmd_buffer[idx] - '0';
+		if (*vlan > 6553 || (*vlan == 6553 && val > 5))
+			return 1;
 		*vlan = (*vlan * 10) + val;
 		idx++;
 	}

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -354,6 +354,8 @@ void parse_vlan(void)
 				print_string("Management VLAN set to "); print_short(management_vlan); write_char('\n');
 			return;
 		}
+		if (!vlan_settings.vlan || vlan_settings.vlan > 4094)
+			goto err;
 		uint8_t w = 2;
 		if (cmd_words_len > w && isletter(cmd_buffer[cmd_words_b[w]])) {
 			register uint8_t i = 0;

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -737,8 +737,8 @@ void parse_mtu(void)
 		return;
 	}
 	atoi_short(&mtu, cmd_words_b[2]);
-	if (mtu > 0x3fff) {
-		print_string("Maximum MTU is 16383\n");
+	if (mtu < 64 || mtu > 0x3fff) {
+		print_string("MTU must be 64..16383\n");
 		return;
 	}
 	REG_WRITE(RTL8373_REG_MAC_L2_PORT_MAX_LEN + ((uint16_t) p << 8), (mtu >> 10) & 0xf, (mtu >> 2) & 0xff,

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -730,14 +730,16 @@ void parse_mtu(void)
 			print_string("Port "); print_byte(machine.log_to_phys_port[p]);
 			write_char(' '); print_short(mtu); write_char('\n');
 		}
+		return;
 	}
-	p = cmd_buffer[cmd_words_b[1]] - '1';
-	p = machine.phys_to_log_port[p];
-	print_byte(p);
-	if (cmd_words_len != 3) {
+	if (cmd_words_len != 3 || cmd_buffer[cmd_words_b[1]] < '1'
+	    || cmd_buffer[cmd_words_b[1]] > '9'
+	    || cmd_buffer[cmd_words_b[1] + 1] > ' ') {
 		print_string("mtu [port] [size]\n");
 		return;
 	}
+	p = machine.phys_to_log_port[cmd_buffer[cmd_words_b[1]] - '1'];
+	print_byte(p);
 	if (atoi_short(&mtu, cmd_words_b[2]) || mtu < 64 || mtu > 0x3fff) {
 		print_string("MTU must be 64..16383\n");
 		return;
@@ -1567,11 +1569,11 @@ void cmd_parser(void) __banked
 			}
 		} else if (cmd_compare(0, "pvid") && cmd_words_len == 3) {
 			__xdata uint16_t pvid;
-			uint8_t port;
-			port = cmd_buffer[cmd_words_b[1]] - '1';
-			port = machine.phys_to_log_port[port];
-			if (!atoi_short(&pvid, cmd_words_b[2]) && pvid && pvid <= 4094)
-				port_pvid_set(port, pvid);
+			if (cmd_buffer[cmd_words_b[1]] >= '1'
+			    && cmd_buffer[cmd_words_b[1]] <= '9'
+			    && cmd_buffer[cmd_words_b[1] + 1] <= ' '
+			    && !atoi_short(&pvid, cmd_words_b[2]) && pvid && pvid <= 4094)
+				port_pvid_set(machine.phys_to_log_port[cmd_buffer[cmd_words_b[1]] - '1'], pvid);
 			else
 				print_string("Error: pvid <port> <1-4094>\n");
 		} else if (cmd_compare(0, "vlan")) {

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -1568,8 +1568,10 @@ void cmd_parser(void) __banked
 			uint8_t port;
 			port = cmd_buffer[cmd_words_b[1]] - '1';
 			port = machine.phys_to_log_port[port];
-			if (!atoi_short(&pvid, cmd_words_b[2]))
+			if (!atoi_short(&pvid, cmd_words_b[2]) && pvid && pvid <= 4094)
 				port_pvid_set(port, pvid);
+			else
+				print_string("Error: pvid <port> <1-4094>\n");
 		} else if (cmd_compare(0, "vlan")) {
 			parse_vlan();
 		} else if (cmd_compare(0, "isolate")) {

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -115,6 +115,9 @@ uint16_t port_pvid_get(uint8_t port) __banked
 
 void vlan_delete(uint16_t vlan) __banked
 {
+	if (!vlan || vlan >= 0xfff)
+		return;
+
 	print_string("\nvlan_delete called \n"); print_short(vlan);
 	vlan_name_remove(vlan);
 	REG_WRITE(RTL837x_TBL_DATA_IN_A, 0, 0, 0, 0);
@@ -197,6 +200,11 @@ __xdata uint16_t vlan_name(register uint16_t vlan) __banked
  */
 void vlan_create(void) __banked
 {
+	if (!vlan_settings.vlan || vlan_settings.vlan >= 0xfff) {
+		print_string("\nInvalid VLAN: "); print_short(vlan_settings.vlan); write_char('\n');
+		return;
+	}
+
 	// For now, the CPU-port is always a tagged member:
 	vlan_settings.members |= 0x0200; // Set 10th bit
 	vlan_settings.tagged |= 0x0200;


### PR DESCRIPTION
Fixes #311. Closes #312.

Seven small commits, all in the same vein: numbers from the CLI reached
registers without anyone checking they fit.

The parser half: atoi_short() and atoi_byte() refuse the digit that would wrap
the value past its type. The command half: vlan_create() and vlan_delete() get
the range check vlan_get() has had all along, parse_vlan() rejects the same
values with the usage message, mtu takes 64 to 16383 and checks the parse result
instead of throwing it away, pvid takes 1 to 4094 and says so when it refuses,
and a management VLAN above 4094 falls to usage rather than parking management
on a VLAN that cannot exist. The last commit validates the port argument of mtu
and pvid: both used to turn the first character into an index with no check, so
"mtu 0 100" read far past the end of phys_to_log_port[] and wrote the size to
whatever register the garbage pointed at. lag and vlan already validated theirs.

Two behaviour notes. A failed parse leaves the partial value alone instead of
tidying it to 0, because 0 is the one number that measurably hurts here: I put
0 in as a port MTU on a live 2.5G LAG member and its LACPDU receives moved by 4
in fifteen seconds against 21 on the sibling port, partner expired, recovered on
restoring the size. That measurement is also where the lower MTU bound comes
from. And "mtu show" gained a return it was missing, so it stops printing a
garbage port byte after the table.

None of it costs internal RAM: cmd_parser.rel stays at DSEG 1, OSEG 2, BSEG 9,
rtl837x_port.rel at DSEG 0, OSEG 5, and the image reports the same 10207 bytes
of XDATA before and after. Every commit builds on its own, so bisect stays
usable.

Boundaries were checked by running the old and new parsing side by side over
65535, 65536, 65540, 255, 256, port words 0, 9, 10, 12, a non-numeric word, and
our own 37-line startup config replays clean against all of the new checks. The
VLAN paths themselves haven't been on hardware: this is built from plain main
and flashing it would take the STP work back off my switch. Say so if you want
that first.

056a30a in #303 fixes atoi_byte by widening the accumulator instead, so it isn't
needed on top of this. Happy to swap to that shape if you prefer it.
