### PR TITLE
Bound the ASIC table waits and act on the result

### DIFF
--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -46,6 +46,18 @@ extern __xdata char sfp_module_model[2][17];
 extern __xdata char sfp_module_serial[2][17];
 extern __xdata uint8_t sfp_options[2];
 
+static __xdata uint16_t hw_guard;
+
+static uint8_t page_tbl_idle(void)
+{
+	hw_guard = 0;
+	do {
+		reg_read_m(RTL837X_TBL_CTRL);
+	} while ((sfr_data[3] & TBL_EXECUTE) && ++hw_guard);
+
+	return !(sfr_data[3] & TBL_EXECUTE);
+}
+
 __code uint8_t * __code HTTP_RESPONCE_JSON = "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n";
 __code uint8_t * __code HTTP_RESPONCE_TXT = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n";
 
@@ -210,9 +222,12 @@ void sfp_send_data(uint8_t slot, uint8_t reg, uint8_t len)
 	reg_bit_set(RTL837X_REG_I2C_CTRL, 0);
 
 	// Wait for execution to finish
+	hw_guard = 0;
 	do {
 		reg_read_m(RTL837X_REG_I2C_CTRL);
-	} while (sfr_data[3] & 0x1);
+	} while ((sfr_data[3] & 0x1) && ++hw_guard);
+	if (sfr_data[3] & 0x1)
+		return;
 
 	for (uint8_t i = 0; i < len; i++) {
 		if (!(i & 0x3))
@@ -338,9 +353,11 @@ void send_l2(uint16_t idx)
 	dbg_short(idx);
 	__xdata uint8_t entries_left = L2_MAX_TRANSFER;
 
-	do {
-		reg_read_m(RTL837X_TBL_CTRL);
-	} while (sfr_data[3] & TBL_EXECUTE);
+	if (!page_tbl_idle()) {
+		char_to_html('[');
+		char_to_html(']');
+		return;
+	}
 
 	/* The L2 table in the ASIC can hold up to 4096 (0x1000) entries, which
 	 * are accessed using an index. The index is the hash of the MAC address
@@ -364,9 +381,12 @@ void send_l2(uint16_t idx)
 		REG_WRITE(RTL837x_TBL_DATA_0, sfr_data[0], sfr_data[1] & 0xfc, sfr_data[2] | (TBL_LUTREAD_NEXT_L2UC << 6), sfr_data[3]);
 
 		REG_WRITE(RTL837X_TBL_CTRL, entry >> 8, entry, TBL_L2_UNICAST, TBL_EXECUTE);
-		do {
-			reg_read_m(RTL837X_TBL_CTRL);
-		} while (sfr_data[3] & TBL_EXECUTE);
+		if (!page_tbl_idle()) {
+			if (first_entry != 0xffff)
+				slen--;
+			char_to_html(']');
+			break;
+		}
 
 		reg_read_m(RTL837x_L2_DATA_OUT_B);
 		if ((sfr_data[0] & 0x20)) {	// Check entry is valid
@@ -432,18 +452,21 @@ void l2_delete(uint16_t idx)
 	dbg_short(idx);
 	__xdata uint8_t entries_left = L2_MAX_TRANSFER;
 
-	do {
-		reg_read_m(RTL837X_TBL_CTRL);
-	} while (sfr_data[3] & TBL_EXECUTE);
+	if (!page_tbl_idle()) {
+		slen += strtox(outbuf + slen, "{\"result\":0}");
+		return;
+	}
 	slen += strtox(outbuf + slen, "{\"result\":");
 	// First, search for the entry based on the index
 	reg_read_m(RTL837x_TBL_DATA_0);
 	REG_WRITE(RTL837x_TBL_DATA_0, sfr_data[0], sfr_data[1] & 0xfc, sfr_data[2] | (TBL_LUTREAD_NEXT_L2UC << 6), sfr_data[3]);
 
 	REG_WRITE(RTL837X_TBL_CTRL, (idx >> 8) & 0xf, idx, TBL_L2_UNICAST, TBL_EXECUTE);
-	do {
-		reg_read_m(RTL837X_TBL_CTRL);
-	} while (sfr_data[3] & 0x1);
+	if (!page_tbl_idle()) {
+		char_to_html('0');
+		char_to_html('}');
+		return;
+	}
 	reg_read_m(RTL837x_L2_DATA_OUT_B);
 	if (!(sfr_data[0] & 0x20)) {
 		char_to_html('0');
@@ -464,11 +487,7 @@ void l2_delete(uint16_t idx)
 		REG_WRITE(RTL837x_TBL_DATA_0, sfr_data[0], sfr_data[1], TBL_L2_UNICAST, sfr_data[3]);
 
 		REG_WRITE(RTL837X_TBL_CTRL, idx >> 8, idx, TBL_L2_UNICAST, TBL_WRITE | TBL_EXECUTE);
-		do {
-			reg_read_m(RTL837X_TBL_CTRL);
-		} while (sfr_data[3] & TBL_EXECUTE);
-
-		char_to_html('1');
+		char_to_html(page_tbl_idle() ? '1' : '0');
 	}
 	char_to_html('}');
 }

--- a/rtl837x_igmp.c
+++ b/rtl837x_igmp.c
@@ -28,6 +28,7 @@ extern __xdata struct machine_runtime machine_detected;
 extern __xdata uint8_t uip_buf[UIP_CONF_BUFFER_SIZE + 2];
 
 __xdata uint16_t idx;
+static __xdata uint16_t igmp_guard;
 
 #ifdef IPMC_USES_L3MC
 struct ipmc_table_entry {
@@ -197,6 +198,16 @@ void entry_to_l2mc(void)
 #endif
 
 
+static uint8_t igmp_tbl_idle(void)
+{
+	igmp_guard = 0;
+	do {
+		reg_read_m(RTL837X_TBL_CTRL);
+	} while ((sfr_data[3] & TBL_EXECUTE) && ++igmp_guard);
+	return !(sfr_data[3] & TBL_EXECUTE);
+}
+
+
 void igmp_packet_handler(void) __banked
 {
 	// By default we do not send anything out
@@ -242,9 +253,8 @@ void igmp_packet_handler(void) __banked
 	entry_to_ipmc();
 #endif
 	// Wait for any pending Table operations to end
-	do {
-		reg_read_m(RTL837X_TBL_CTRL);
-	} while (sfr_data[3] & 1);
+	if (!igmp_tbl_idle())
+		return;
 
 	reg_read_m(RTL837x_TBL_DATA_0);
 #ifdef DEBUG
@@ -259,9 +269,8 @@ void igmp_packet_handler(void) __banked
 #endif
 	// First try to find entry to see whether it needs to be updated
 	REG_WRITE(RTL837X_TBL_CTRL, 0x00, 0x00, TBL_L2_UNICAST, TBL_EXECUTE);
-	do {
-		reg_read_m(RTL837X_TBL_CTRL);
-	} while (sfr_data[3] & 0x1);
+	if (!igmp_tbl_idle())
+		return;
 #ifdef DEBUG
 	print_string("\nsearch done\n");
 	print_string("Table data searched:\n");
@@ -323,9 +332,8 @@ void igmp_packet_handler(void) __banked
 			sfr_data[1] |= 0x04;	// Clear entry
 			reg_write_m(RTL837x_TBL_DATA_0);
 			REG_WRITE(RTL837X_TBL_CTRL, idx >> 8, idx & 0xff, TBL_L2_UNICAST, TBL_WRITE | TBL_EXECUTE);
-			do {
-				reg_read_m(RTL837X_TBL_CTRL);
-			} while (sfr_data[3] & 0x1);
+			if (!igmp_tbl_idle())
+				return;
 			print_string("IGMP Entry deleted\n");
 			return;
 		}
@@ -355,9 +363,8 @@ void igmp_packet_handler(void) __banked
 #endif
 	reg_read_m(RTL837X_TBL_CTRL);
 	REG_WRITE(RTL837X_TBL_CTRL, sfr_data[0], sfr_data[1], TBL_L2_UNICAST, TBL_WRITE | TBL_EXECUTE);
-	do {
-		reg_read_m(RTL837X_TBL_CTRL);
-	} while (sfr_data[3] & 0x1);
+	if (!igmp_tbl_idle())
+		return;
 #ifdef DEBUG
 	print_string("\nupdate done\n");
 	print_string("Table data written:\n");

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -28,6 +28,18 @@ extern __xdata struct machine_runtime machine_detected;
 
 __xdata	uint32_t l2_head;
 
+static __xdata uint16_t tbl_guard;
+
+static uint8_t port_tbl_idle(void)
+{
+	tbl_guard = 0;
+	do {
+		reg_read_m(RTL837X_TBL_CTRL);
+	} while ((sfr_data[3] & TBL_EXECUTE) && ++tbl_guard);
+
+	return !(sfr_data[3] & TBL_EXECUTE);
+}
+
 __xdata struct vlan_settings vlan_settings;
 
 void port_mirror_set(register uint8_t port, __xdata uint16_t rx_pmask, __xdata uint16_t tx_pmask) __banked
@@ -168,9 +180,8 @@ int8_t vlan_get(register uint16_t vlan) __banked
 		return -1;
 
 	REG_WRITE(RTL837X_TBL_CTRL, vlan >> 8, vlan, TBL_VLAN, TBL_EXECUTE);
-	do {
-		reg_read_m(RTL837X_TBL_CTRL);
-	} while (sfr_data[3] & TBL_EXECUTE);
+	if (!port_tbl_idle())
+		return -1;
 	reg_read_m(RTL837x_L2_DATA_OUT_A);
 
 	return 0;
@@ -224,9 +235,8 @@ void vlan_create(void) __banked
 	// Initialize VLAN table with VLAN 1
 	REG_WRITE(RTL837x_TBL_DATA_IN_A, 0x02, (a >> 6) & 0x0f, (a << 2) | (vlan_settings.members >> 8), vlan_settings.members);
 	REG_WRITE(RTL837X_TBL_CTRL, vlan_settings.vlan >> 8, vlan_settings.vlan, TBL_VLAN, TBL_WRITE | TBL_EXECUTE);
-	do {
-		reg_read_m(RTL837X_TBL_CTRL);
-	} while (sfr_data[3] & TBL_EXECUTE);
+	if (!port_tbl_idle())
+		return;
 	print_string("vlan_create done \n");
 }
 
@@ -328,9 +338,12 @@ uint8_t port_l2_forget(void) __banked
 	REG_SET(RTL837x_L2_TBL_FLUSH_CTRL, L2_TBL_FLUSH_EXEC | (machine_detected.isRTL8373 ? PMASK_9 : PMASK_6));
 
 	// Wait for flush completed
+	tbl_guard = 0;
 	do {
 		reg_read_m(RTL837x_L2_TBL_FLUSH_CTRL);
-	} while (sfr_data[1]);
+	} while (sfr_data[1] && ++tbl_guard);
+	if (sfr_data[1])
+		return 0;
 
 	print_string("port_l2_forget done\n");
 	return 0;
@@ -340,9 +353,8 @@ uint8_t port_l2_forget(void) __banked
 void port_l2_learned(void) __banked
 {
 	// Whait for any table action to be finished
-	do {
-		reg_read_m(RTL837X_TBL_CTRL);
-	} while (sfr_data[3] & 0x01);
+	if (!port_tbl_idle())
+		return;
 	print_string("\n\tMAC\t\tVLAN\ttype\tport\n");
 	__xdata uint16_t entry = 0x0000;
 	__xdata uint16_t first_entry = 0xffff; // Table does not have that many entries
@@ -353,9 +365,8 @@ void port_l2_learned(void) __banked
 		REG_WRITE(RTL837x_TBL_DATA_0, sfr_data[0], sfr_data[1],sfr_data[2] | 0xc0, sfr_data[3]);
 
 		REG_WRITE(RTL837X_TBL_CTRL, (entry >> 8) & 0xf, entry, TBL_L2_UNICAST, TBL_EXECUTE);
-		do {
-			reg_read_m(RTL837X_TBL_CTRL);
-		} while (sfr_data[3] & TBL_EXECUTE);
+		if (!port_tbl_idle())
+			break;
 
 		reg_read_m(RTL837x_TBL_DATA_0);
 		entry = (((uint16_t)sfr_data[2] & 0x0f) << 8) | sfr_data[3];


### PR DESCRIPTION
Seventeen spots across three modules poll an ASIC engine for a table operation to
finish, and if the engine never clears its execute bit they spin for ever. Nothing
else runs on the 8051 to notice, so management disappears while the ASIC keeps
forwarding, which is a miserable thing to diagnose from the outside.

The review on #314 asked for these to be rethought, and that objection was right. A
bound on its own is the dangerous half. The code gives up and then carries on as
if the operation had finished, reading a data register that was never filled or
reporting a delete that may never have happened. That is how I bricked this switch
twice in August, and the way back was an SPI clip.

So fifteen of them now report whether the engine actually went idle, and every
caller does something honest with that. vlan_get returns the -1 it already has.
vlan_create and port_l2_learned return without printing a result. port_l2_forget
skips its done line. The walks over the L2 table break out rather than read an
entry the engine never produced. In the web server the response is half written by
the time the wait fails, so send_l2 closes its array and drops the separator it had
already emitted, l2_delete answers 0 exactly as it does for an entry it cannot
find, and the SFP read leaves its hex field empty instead of filling it from an
output register the controller never wrote, which would come back looking like a
plausible temperature.

One caller does not benefit yet, and it is worth naming here rather than leaving it
to turn up in review: send_vlan ignores the -1 vlan_get hands back, as it already ignores
the one for an out of range id, so it renders whatever the last read left behind.
That fault is older than this and belongs with that function.

The remaining two waits are deliberately left unbounded, both in vlan_setup. That
one runs from the boot sequence before anything else is up, and a switch that comes up with half
a VLAN table written is worse than one that visibly never finishes starting. There
is nothing there to fall back to, so hanging where you can see it is the better
failure.

I measured the worst case on hardware rather than guessing at it. Real silicon will
not wedge its table engine on request, so what I timed was a loop of the same shape
driven to exhaustion on the switch: 65536 register reads cost 0.23 s, about 3.5 us
each, four runs with a spread under 7 ms. So the pathological case blocks management for a quarter of a
second instead of for ever. The same number says why 8 bits was not enough. It
would have given up after 0.9 ms, which sits inside ordinary contention for the
table, and giving up early is exactly what hurts.

The premise turned up on its own while I was testing. Management died on me for an
unrelated reason, the one in #298, and the switch carried on switching without a
flicker: traffic through it was untouched the whole time the management CPU was
gone and the switch would not answer a ping.

The healthy path I exercised on the switch as well, since a guard that broke
ordinary operation would be worse than no guard. The L2 and VLAN pages answer
exactly what they answered before, vlan_create and port_l2_forget both print their
done line, the flush empties the table, and port_l2_learned walks it and prints
what is there.

The giving up itself I could only test off the switch. There are host tests for
every one of these fifteen spots, using the harness in #324, with an engine that
can be told to wedge after a chosen number of successful polls. Run against the code as it is today all three suites trip that harness's
watchdog, which is what makes them worth anything. They are not in this PR because
#324 has not landed yet; I will send them separately once it does.

Three commits, one per module, separable if you want to take them at different
speeds. Sizes against main with both trees built from the same version string:
BANK1 grows by 309 bytes, BANK2 is unchanged, and image xdata goes from 10207 to
10213. Each helper's result costs one bit of BSEG, which fits inside the two bytes
of bit space the image already reserves, so DSEG, OSEG and the stack base are
untouched.
