### PR TITLE
httpd: stop the GET request line walk at the end of the buffer

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -640,7 +640,7 @@ void httpd_appcall(void)
 		p += 4;
 		scan_header(p);
 		__xdata uint8_t *q = p;
-		while (!is_separator(*p))
+		while (*p && !is_separator(*p))
 			p++;
 		*p = '\0';
 		dbg_string_x(q);


### PR DESCRIPTION
I found this while running the httpd request path under ASan on the host: a request line that carries no space, tab, question mark or equals walks past the end of `uip_buf` and writes its terminator wherever it happens to stop.

The POST path already tests for a NUL before it looks at a byte. The GET path doesn't, and `is_separator()` counts only those four characters, so nothing ends the walk at the end of the buffer.

What makes it easy to reach is that everything which isn't a POST arrives at that loop. The pointer moves past the method before anything checks that the method was GET, so `is_word(p, "GET")` only decides whether a debug line gets printed. A TLS record sent to port 80 by a browser trying https first is enough on its own, and so is a port scanner or a malformed line.

The symptoms are erratic because the walk stops at the first matching byte it finds in xdata. Sometimes nothing visible happens, sometimes something unrelated breaks later, and the two are hard to connect.

The fix is one condition. It costs two bytes of BANK1; BANK2 and xdata don't move.

On the current code ASan reports a WRITE memory access at `httpd.c:645`. The same input passes cleanly after the change.
