### PR TITLE
httpd: answer /cmd with what the command printed, and show it in the console tab

### DIFF
--- a/html/system.html
+++ b/html/system.html
@@ -88,6 +88,8 @@
       <input style="width:20%;" class="action" id="cmd_sub" onclick="cmdSub();" type="button" data-i18n="sys_send_cmd" value="Send Command"><br/>
       <br/><br/> 
       <span data-i18n="sys_console_warn">Be careful when entering console commands, you can lock yourself out!</span><br/>
+      <br/>
+      <pre id="console_out" style="height:22em;overflow:auto;white-space:pre-wrap;border:1px solid;padding:0.5em;"></pre>
 
     </div>
 

--- a/html/system.js
+++ b/html/system.js
@@ -43,7 +43,16 @@ async function cmdSub() {
       method: 'POST',
       body: cmd
     });
-    out.textContent += "> " + cmd + "\n" + await response.text();
+    if (response.status == 401) {
+      window.location.href = 'login.html';
+      return;
+    }
+    let text = await response.text();
+    if (text != "" && !text.endsWith("\n"))
+      text += "\n";
+    if (out.textContent.length > 20000)
+      out.textContent = out.textContent.slice(-16000);
+    out.textContent += "> " + cmd + "\n" + text;
     out.scrollTop = out.scrollHeight;
     input.value = "";
   } catch(err) {

--- a/html/system.js
+++ b/html/system.js
@@ -35,14 +35,19 @@ async function ipSub() {
 }
 
 async function cmdSub() {
-  var cmd = document.getElementById('console_cmd').value;
+  const input = document.getElementById('console_cmd');
+  const out = document.getElementById('console_out');
+  const cmd = input.value;
   try {
     const response = await fetch('/cmd', {
       method: 'POST',
       body: cmd
     });
-    console.log('Completed!', response);
+    out.textContent += "> " + cmd + "\n" + await response.text();
+    out.scrollTop = out.scrollHeight;
+    input.value = "";
   } catch(err) {
+      out.textContent += "> " + cmd + "\n" + err + "\n";
       console.error(`Error: ${err}`);
   }
 }

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -16,11 +16,6 @@
 
 #define CMARK_S 6
 
-/* Answer to POST /cmd. Kept as a macro so that its length is known at compile
- * time: an unchanged slen afterwards means the command printed nothing. */
-#define CMD_RESPONSE_HEADER "HTTP/1.1 200 OK\r\nConnection: close\r\n" \
-			    "Content-Type: text/plain\r\n\r\n"
-
 #pragma codeseg BANK1
 #pragma constseg BANK1
 
@@ -631,7 +626,9 @@ static void handle_firmware_fragment(__xdata uint8_t *p)
 
 static void run_cmd_body(__xdata uint8_t *body)
 {
-	slen = strtox(outbuf, CMD_RESPONSE_HEADER);
+	uint16_t hdr_len = strtox(outbuf, HTTP_RESPONCE_TXT);
+
+	slen = hdr_len;
 	cmd_capture = 1;
 	execute_commands(body);
 	if (cmd_capture == 2)
@@ -640,7 +637,7 @@ static void run_cmd_body(__xdata uint8_t *body)
 	/* Commands that configure something print nothing at all. Saying
 	 * so beats an empty body, which reads the same as "nothing ran".
 	 * Only on success: a silent failure must not answer with "OK". */
-	if (err_status == ERR_OK && slen == sizeof(CMD_RESPONSE_HEADER) - 1)
+	if (err_status == ERR_OK && slen == hdr_len)
 		slen += strtox(outbuf + slen, "OK\n");
 	/* On a parse error keep what the parser printed, because that text
 	 * is the explanation, and only restate the status. "400 NO" is as

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -16,12 +16,17 @@
 
 #define CMARK_S 6
 
+/* Answer to POST /cmd. Kept as a macro so that its length is known at compile
+ * time: an unchanged slen afterwards means the command printed nothing. */
+#define CMD_RESPONSE_HEADER "HTTP/1.1 200 OK\r\nConnection: close\r\n" \
+			    "Content-Type: text/plain\r\n\r\n"
+
 #pragma codeseg BANK1
 #pragma constseg BANK1
 
 extern volatile __xdata uint8_t sfr_data[4];
 extern volatile __xdata uint32_t ticks;
-extern __xdata uint8_t cmd_capture;	/* owned by rtlplayground.c, see write_char() */
+extern __xdata uint8_t cmd_capture;	/* owned by rtlplayground.c, see write_char_no_syslog() */
 extern __code uint8_t * __code hex;
 extern __code struct f_data f_data[];
 extern __code char * __code mime_strings[];
@@ -626,14 +631,26 @@ static void handle_firmware_fragment(__xdata uint8_t *p)
 
 static void run_cmd_body(__xdata uint8_t *body)
 {
-	slen = strtox(outbuf, "HTTP/1.1 200 OK\r\nConnection: close\r\n" \
-			      "Content-Type: text/plain\r\n\r\n");
+	slen = strtox(outbuf, CMD_RESPONSE_HEADER);
 	cmd_capture = 1;
 	execute_commands(body);
+	if (cmd_capture == 2)
+		slen += strtox(outbuf + slen, CMD_TRUNCATED);
 	cmd_capture = 0;
+	/* Commands that configure something print nothing at all. Saying
+	 * so beats an empty body, which reads the same as "nothing ran".
+	 * Only on success: a silent failure must not answer with "OK". */
+	if (err_status == ERR_OK && slen == sizeof(CMD_RESPONSE_HEADER) - 1)
+		slen += strtox(outbuf + slen, "OK\n");
+	/* On a parse error keep what the parser printed, because that text
+	 * is the explanation, and only restate the status. "400 NO" is as
+	 * long as "200 OK", so the header does not have to be rebuilt. */
 	if (err_status != ERR_OK) {
-		send_bad_request();
-		return;
+		outbuf[9] = '4';
+		outbuf[10] = '0';
+		outbuf[11] = '0';
+		outbuf[13] = 'N';
+		outbuf[14] = 'O';
 	}
 }
 

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -21,6 +21,7 @@
 
 extern volatile __xdata uint8_t sfr_data[4];
 extern volatile __xdata uint32_t ticks;
+extern __xdata uint8_t cmd_capture;	/* owned by rtlplayground.c, see write_char() */
 extern __code uint8_t * __code hex;
 extern __code struct f_data f_data[];
 extern __code char * __code mime_strings[];
@@ -625,12 +626,15 @@ static void handle_firmware_fragment(__xdata uint8_t *p)
 
 static void run_cmd_body(__xdata uint8_t *body)
 {
+	slen = strtox(outbuf, "HTTP/1.1 200 OK\r\nConnection: close\r\n" \
+			      "Content-Type: text/plain\r\n\r\n");
+	cmd_capture = 1;
 	execute_commands(body);
+	cmd_capture = 0;
 	if (err_status != ERR_OK) {
 		send_bad_request();
 		return;
 	}
-	send_ok();
 }
 
 

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -48,7 +48,7 @@ extern __xdata char sfp_module_serial[2][17];
 extern __xdata uint8_t sfp_options[2];
 
 __code uint8_t * __code HTTP_RESPONCE_JSON = "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n";
-__code uint8_t * __code HTTP_RESPONCE_TXT = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n";
+__code uint8_t * __code HTTP_RESPONCE_TXT = "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: text/plain\r\n\r\n";
 
 // Convert uint8_t to ascii HEX char push on html-buffer.
 void charhex_to_html(char c)

--- a/httpd/page_impl.h
+++ b/httpd/page_impl.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 
+extern __code uint8_t * __code HTTP_RESPONCE_TXT;
+
 bool send_counters(uint8_t phys_port);
 void send_status(void);
 void send_vlan(uint16_t vlan);

--- a/rtl837x_common.h
+++ b/rtl837x_common.h
@@ -37,6 +37,10 @@ extern __xdata uint8_t sbuf[SBUF_SIZE];
 // Size of the TCP Output buffer
 #define TCP_OUTBUF_SIZE 2500
 
+// Appended when a captured command wrote more than the output buffer holds,
+// so a clipped listing is visibly clipped instead of silently short.
+#define CMD_TRUNCATED "\n[output truncated]\n"
+
 // Size of the port name, including the terminating null byte
 #define PORT_NAME_SIZE 32
 

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -248,6 +248,17 @@ extern __xdata uint16_t slen;
 
 void write_char_no_syslog(char c)
 {
+	/* Capturing sits here rather than in write_char() so that the messages
+	 * printed through print_string_no_syslog() are captured too: those are
+	 * the replies of the syslog commands, which must not generate a syslog
+	 * packet but do belong in the answer to a command sent over HTTP. */
+	if (cmd_capture) {
+		if (slen < TCP_OUTBUF_SIZE - sizeof(CMD_TRUNCATED))
+			outbuf[slen++] = c;
+		else
+			cmd_capture = 2;	/* out of room, httpd says so */
+	}
+
 	do {
 	} while (tx_buf_empty == 0);
 	if (c =='\n') {
@@ -262,9 +273,6 @@ void write_char_no_syslog(char c)
 
 void write_char(char c)
 {
-	if (cmd_capture && slen < TCP_OUTBUF_SIZE - 1)
-		outbuf[slen++] = c;
-
 	write_char_no_syslog(c);
 
 	if (syslog_state.enabled) {

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -240,6 +240,12 @@ void isr_serial(void) __interrupt(4)
 }
 
 
+/* Set by the httpd while it runs a command that arrived over the network, so
+ * that everything the command prints lands in the response as well. */
+__xdata uint8_t cmd_capture;
+extern __xdata uint8_t outbuf[TCP_OUTBUF_SIZE];
+extern __xdata uint16_t slen;
+
 void write_char_no_syslog(char c)
 {
 	do {
@@ -256,6 +262,9 @@ void write_char_no_syslog(char c)
 
 void write_char(char c)
 {
+	if (cmd_capture && slen < TCP_OUTBUF_SIZE - 1)
+		outbuf[slen++] = c;
+
 	write_char_no_syslog(c);
 
 	if (syslog_state.enabled) {


### PR DESCRIPTION
Two small commits that belong together. Either one on its own doesn't get you anything.

`POST /cmd` runs the command and answers with an empty 200, so the caller can't tell whether it worked, was refused, or was just misspelt, and whatever the command printed only reaches the serial console. Reading a register over the network means finding a second channel to see the answer, which is how I ended up watching syslog to check a value I had written a moment earlier.

`write_char()` is the one funnel every console helper goes through, and it already tees into the syslog ring. A third sink, live only while the httpd is running a command that arrived over the network, drops the same bytes into the response behind the header. Serial and syslog keep their copy on purpose: I nearly suppressed them, then remembered I had been leaning on syslog for exactly this an hour before. The capture stops at the end of the response buffer, so a long listing is truncated rather than running past it.

The System page already has a Console tab, but `cmdSub()` threw the response away, and until now there was nothing in it to keep. It holds a transcript now: the command after a prompt, then whatever it printed. The box is a `pre` filled through `textContent`, so nothing the device prints gets taken for markup.

39 bytes of BANK1 and 52 of the common area, one byte of xdata, BANK2 unchanged.

Tried on a SWTGW218AS: `regget` comes back with the value, `version` with its three lines, a misspelt command with `Unknown command`, and `vlan show` with the whole table.
