### PR TITLE
Sram easy changes

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -50,8 +50,8 @@ __xdata uint8_t config_upload;
 __xdata uint8_t config_buf[CONFIG_UPLOAD_BUF];
 __xdata uint16_t cfg_pos, cfg_hdr, cfg_body, cfg_end, cfg_last;
 __xdata uint8_t cfg_bl;
-__xdata uint8_t *content_type = 0;
-__xdata uint8_t *session = 0;
+__xdata uint8_t * __xdata content_type = 0;
+__xdata uint8_t * __xdata session = 0;
 
 // Global variables holding POST state
 __xdata uint16_t bindex; // Current index into the boundary
@@ -63,7 +63,7 @@ __xdata char passwd[21];
 __xdata char session_id[SESSION_ID_LENGTH + 1];
 __xdata uint8_t authenticated;
 __xdata uint32_t now;
-__xdata uint8_t *timeptr;
+__xdata uint8_t * __xdata timeptr;
 __xdata uint32_t last_session_use;
 
 #define TSTATE_NONE		0
@@ -311,7 +311,7 @@ __xdata uint8_t *scan_header(__xdata uint8_t *p)
 }
 
 
-void gen_random_bytes(__xdata uint8_t *b, uint8_t bytes)
+void gen_random_bytes(__xdata uint8_t *b, register uint8_t bytes)
 {
 	__xdata uint8_t i = 0;
 	while (bytes) {

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -310,10 +310,12 @@ __xdata uint8_t *scan_header(__xdata uint8_t *p)
 	return p;
 }
 
-
-void gen_random_bytes(__xdata uint8_t *b, register uint8_t bytes)
+/*
+ * Generate random HEX-chars at the buffer location.
+ */
+void gen_random_hex_chars(__xdata uint8_t * b, __xdata uint8_t bytes)
 {
-	__xdata uint8_t i = 0;
+	uint8_t i = 0;
 	while (bytes) {
 		if (!i)
 			get_random_32();
@@ -549,7 +551,7 @@ void handle_post(void)
 		if (is_url_word_x(p, passwd)) {
 			dbg_string("Password accepted!\n");
 			read_reg_timer(&last_session_use);
-			gen_random_bytes(session_id, SESSION_ID_LENGTH);
+			gen_random_hex_chars(session_id, SESSION_ID_LENGTH);
 			session_id[SESSION_ID_LENGTH] = NUL;
 			slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nConnection: close\r\nLocation: index.html\r\n" \
 					      "Set-Cookie: session=");

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -175,7 +175,7 @@ bool is_url_word_x(__xdata uint8_t *uri_str_p, __xdata uint8_t *src_str_p)
 }
 
 
-bool is_word_x(__xdata uint8_t *lhs_str_p, __xdata uint8_t *rhs_str_p)
+bool is_word_x(__xdata uint8_t * lhs_str_p, __xdata uint8_t * rhs_str_p)
 {
 	uint8_t u, c;
 
@@ -251,7 +251,7 @@ __xdata uint8_t *skip_boundary(__xdata uint8_t *p)
 }
 
 
-__xdata uint8_t *scan_header(__xdata uint8_t *p)
+__xdata uint8_t *scan_header(__xdata uint8_t * __xdata p)
 {
 	content_type = 0;
 	session = 0;

--- a/syslog.c
+++ b/syslog.c
@@ -62,19 +62,19 @@ void syslog_callback(uint16_t lport) __banked
 
 	if ((state.readptr != state.writeptr) && state.line_available)
 	{
-		int16_t log_size = state.writeptr - state.readptr;
+		__xdata int16_t log_size = state.writeptr - state.readptr;
 		if (log_size < 0)
 			log_size += LOGBUF_SIZE;
 		
 		// Skipping linefeeds at the start of the log line
-		uint16_t log_start = state.readptr;
+		__xdata uint16_t log_start = state.readptr;
 		while (log_size > 0 && logbuf[log_start] == '\n') {
 			log_start = (log_start + 1) & (LOGBUF_SIZE - 1);
 			log_size--;
 		}
 
 		// Skipping linefeeds and whitespaces at the end of the log line
-		uint16_t log_end = state.writeptr;
+		__xdata uint16_t log_end = state.writeptr;
 		while ( (log_size > 0) && 
 				((logbuf[(log_end-1) & (LOGBUF_SIZE - 1)] == '\n') ||
 				 (logbuf[(log_end-1) & (LOGBUF_SIZE - 1)] == ' ')))
@@ -95,7 +95,7 @@ void syslog_callback(uint16_t lport) __banked
 			memcpy(SYSLOG_P + 4, logbuf + log_start, LOGBUF_SIZE - log_start);
 			memcpy(SYSLOG_P + 4 + LOGBUF_SIZE - log_start, logbuf, log_end);
 		} else {
-			 memcpy(SYSLOG_P + 4, logbuf + log_start, log_end - log_start);
+			memcpy(SYSLOG_P + 4, logbuf + log_start, log_end - log_start);
 		}
 
 		uip_udp_send(log_size+4);

--- a/uip/uip.c
+++ b/uip/uip.c
@@ -157,7 +157,7 @@ __xdata u16_t uip_len, uip_slen;
 __xdata u8_t uip_flags;     /* The uip_flags variable is used for
 				communication between the TCP/IP stack
 				and the application program. */
-__xdata struct uip_conn *uip_conn;   /* uip_conn always points to the current
+__xdata struct uip_conn * __xdata uip_conn;   /* uip_conn always points to the current
 				connection. */
 
 __xdata struct uip_conn uip_conns[UIP_CONNS];
@@ -167,7 +167,7 @@ __xdata u16_t uip_listenports[UIP_LISTENPORTS];
                              /* The uip_listenports list all currently
 				listning ports. */
 #if UIP_UDP
-__xdata struct uip_udp_conn *uip_udp_conn;
+__xdata struct uip_udp_conn * __xdata uip_udp_conn;
 __xdata struct uip_udp_conn uip_udp_conns[UIP_UDP_CONNS];
 #endif /* UIP_UDP */
 
@@ -466,7 +466,7 @@ uip_connect(register __xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banke
 /*---------------------------------------------------------------------------*/
 #if UIP_UDP
 __xdata struct uip_udp_conn *
-uip_udp_new(__xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banked
+uip_udp_new(__xdata uip_ipaddr_t * __xdata ripaddr, __xdata u16_t rport) __banked
 {
   __xdata struct uip_udp_conn *conn;
   

--- a/uip/uip.h
+++ b/uip/uip.h
@@ -763,7 +763,7 @@ void uip_send(__xdata const void *data, __xdata uint16_t len) __banked;
  * \return The uip_udp_conn structure for the new connection or NULL
  * if no connection could be allocated.
  */
-__xdata struct uip_udp_conn *uip_udp_new(__xdata uip_ipaddr_t *ripaddr, __xdata u16_t rport) __banked;
+__xdata struct uip_udp_conn *uip_udp_new(__xdata uip_ipaddr_t * __xdata ripaddr, __xdata u16_t rport) __banked;
 
 /**
  * Removed a UDP connection.
@@ -1193,7 +1193,7 @@ struct uip_conn {
  * The uip_conn pointer can be used to access the current TCP
  * connection.
  */
-extern __xdata struct uip_conn *uip_conn;
+extern __xdata struct uip_conn * __xdata uip_conn;
 /* The array containing all uIP connections. */
 extern __xdata struct uip_conn uip_conns[UIP_CONNS];
 /**
@@ -1226,7 +1226,7 @@ struct uip_udp_conn {
 /**
  * The current UDP connection.
  */
-extern __xdata struct uip_udp_conn *uip_udp_conn;
+extern __xdata struct uip_udp_conn * __xdata uip_udp_conn;
 extern __xdata struct uip_udp_conn uip_udp_conns[UIP_UDP_CONNS];
 #endif /* UIP_UDP */
 

--- a/uip/uip_arp.c
+++ b/uip/uip_arp.c
@@ -175,7 +175,7 @@ uip_arp_timer(void) __banked
 }
 /*-----------------------------------------------------------------------------------*/
 static void
-uip_arp_update(__xdata u16_t *ipaddr, __xdata struct uip_eth_addr *ethaddr)
+uip_arp_update(__xdata u16_t * __xdata ipaddr, __xdata struct uip_eth_addr * __xdata ethaddr)
 {
   uint8_t i;
   /* Walk through the ARP mapping table and try to find an entry to


### PR DESCRIPTION
These are the easy changes to free-up SRAM usage by the code/compiler.

Looking in the build directory, generated asm-files.
See which functions passed arguments via SRAM or put local variable also SRAM because compiler has no space.

Example from `httpd.asm`.
```
;--------------------------------------------------------
; internal ram data
;--------------------------------------------------------
	.area DSEG    (DATA)
_content_type::
	.ds 2
_session::
	.ds 2
_timeptr::
	.ds 2
_scan_header_p_10000_152:
	.ds 2
_gen_random_bytes_PARM_2:
	.ds 1
```

You can see that `content_type`, `session` and `timeptr` are placed in SRAM.
Fix was simple, add `__xdata` to the declaration so the compiler put it in XDATA.

Sometimes you have to look into the code, to see that compiler stores the passed argument direcly in SRAM at the begin of the function to make room for other things.
Like `scan_header_p_10000_152`, many thing this can be fixed by passing that argument via xdata.

```patch
4,10c4,10
< 0x10:|b|b|b|b|b|b|b|b|b|b|b|c|c|c|c|k|
< 0x20:|B|B|T|d|d|e|e|e|e|e|e|e|e|e|e|e|
< 0x30:|e|e|e|e|e|e|e|e|e|e|e|e|e|e|e|e|
< 0x40:|e|e|f|f|f|f|f|g|g|g|g|g|g|g|g|g|
< 0x50:|g|g|g|g|g|g|h|h|h|h|h|h|h|h|h|h|
< 0x60:|i|i|i|i|i|i|i|i|i|j|j|j|j|j|j|j|
< 0x70:|j|j|j|j|j|Q|Q|Q|Q|Q|Q|Q|Q|S|S|S|
---
> 0x10:|b|b|b|b|b|b|b|b|b|b|b|c|c|g|g|g|
> 0x20:|B|B|T|d|d|d|d|d|d|d|d|d|d|d|d|d|
> 0x30:|d|d|d|d|d|d|d|d|d|d|d|e|e|e|e|e|
> 0x40:|f|f|f|f|f|f|f|f|f|h|h|h|h|h|h|h|
> 0x50:|h|h|i|i|i|i|i|i|i|i|i|i|i|i|j|Q|
> 0x60:|Q|Q|Q|Q|Q|Q|Q|S|S|S|S|S|S|S|S|S|
> 0x70:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
21c21
< 16 bit mode initial stack starts at: 0x7d (sp set to 0x7c) with 131 bytes available.
---
> 16 bit mode initial stack starts at: 0x67 (sp set to 0x66) with 153 bytes available.
28,29c28,29
<    EXTERNAL RAM     0x0001   0x27df   10207    16777216
<    ROM/EPROM/FLASH  0x0000   0x2d59a  96027    16777216
---
>    EXTERNAL RAM     0x0001   0x27f7   10231    16777216
>    ROM/EPROM/FLASH  0x0000   0x2d5c2  96330    16777216
```

Free up 22 bytes of SRAM-bytes