### PR TITLE
regs: wrap REG_SET and REG_WRITE, and fix what that uncovers

### DIFF
--- a/rtl837x_regs.h
+++ b/rtl837x_regs.h
@@ -305,32 +305,40 @@
 
 #ifdef REGDBG
 
-#define REG_SET(r, v) SFR_DATA_24 = (((uint32_t)v) >> 24) & 0xff; \
+#define REG_SET(r, v) do { \
+	SFR_DATA_24 = (((uint32_t)v) >> 24) & 0xff; \
 	SFR_DATA_16 = (((uint32_t)v) >> 16) & 0xff; \
 	SFR_DATA_8 = (((uint16_t)v) >> 8 & 0xff); \
 	SFR_DATA_0 = (v) & 0xff; \
 	reg_write(r); \
 	write_char('R'); print_byte(r >> 8); print_byte(r); write_char('-'); \
-	print_byte(((v) >> 24) & 0xff); print_byte((v) >> 16 & 0xff); print_byte((v) >> 8 & 0xff); print_byte( (v) & 0xff); write_char(' ');
+	print_byte(((v) >> 24) & 0xff); print_byte((v) >> 16 & 0xff); print_byte((v) >> 8 & 0xff); print_byte( (v) & 0xff); write_char(' '); \
+} while (0)
 
-#define	REG_WRITE(r, v24, v16, v8, v0) SFR_DATA_24 = (v24); \
+#define	REG_WRITE(r, v24, v16, v8, v0) do { \
+	SFR_DATA_24 = (v24); \
 	SFR_DATA_16 = (v16); \
 	SFR_DATA_8 = (v8); \
 	SFR_DATA_0 = (v0); \
 	reg_write(r); \
-	write_char('R'); print_byte(r>>8); print_byte(r); write_char('-'); print_byte(v24); print_byte(v16); print_byte(v8); print_byte(v0); write_char(' ');
+	write_char('R'); print_byte(r>>8); print_byte(r); write_char('-'); print_byte(v24); print_byte(v16); print_byte(v8); print_byte(v0); write_char(' '); \
+} while (0)
 #else
-#define REG_SET(r, v) SFR_DATA_24 = (((uint32_t)v) >> 24) & 0xff; \
+#define REG_SET(r, v) do { \
+	SFR_DATA_24 = (((uint32_t)v) >> 24) & 0xff; \
 	SFR_DATA_16 = (((uint32_t)v) >> 16) & 0xff; \
 	SFR_DATA_8 = (((uint16_t)v) >> 8 & 0xff); \
 	SFR_DATA_0 = (v) & 0xff; \
-	reg_write(r);
+	reg_write(r); \
+} while (0)
 
-#define	REG_WRITE(r, v24, v16, v8, v0) SFR_DATA_24 = (v24); \
+#define	REG_WRITE(r, v24, v16, v8, v0) do { \
+	SFR_DATA_24 = (v24); \
 	SFR_DATA_16 = (v16); \
 	SFR_DATA_8 = (v8); \
 	SFR_DATA_0 = (v0); \
-	reg_write(r);
+	reg_write(r); \
+} while (0)
 #endif
 
 #endif


### PR DESCRIPTION
`REG_SET` and `REG_WRITE` expand to a run of statements with no do/while around them, so as the unbraced body of an `if` or a `for` only the first assignment belongs to that body. The other three and the `reg_write()` call sit after it and run once, unconditionally, with whatever the loop counter ended on.

Five call sites are written that way. Wrapping the four definitions fixes them without touching a single one, and the two follow-up commits deal with what the restored guards then expose.

What it looks like on an SWTGW218AS, all read back with `regget` after a cold boot.

The IGMP one is the clearest. `igmp_setup()` loops over the ports to install the per-port configuration, and the write landed once, at `machine.max_port + 1`, so the ports themselves never got it. Before: every port read `0x00ff7c00`, the reset state, while index 9 held the `0x00ff7c15` the loop meant for them, and `igmp off` left a preceding `igmp on` in place until the next reboot. After: ports read `0x00ff7c15` and `igmp off` restores it. `igmp_enable()` has the same loop with braces around it and was always correct, which is why turning snooping on worked and turning it off did not.

I marked three unused ports with `0x00ff7c3f` and called `igmp off` to find where the write was going: the marks survived and `0x52c4` picked up the value, which is index 9 rather than any port.

Two sites change behaviour once the guard works again, and both wanted fixing rather than leaving.

`port_lag_members_set()` installs `LAG_HASH_DEFAULT` when the hash register reads all zeros. That test never passes, because the register comes out of reset holding `0x3f`, so with the guard restored the default would never be installed where before it was installed on every call. The same line also wrote to the base address while the read that decides it used the group offset, so a group other than zero was tested and group zero was written. Both ends use the offset now and the test is against the reset value, which the header names. Measured across three images on the same switch: the hash for the configured group went `0x7e`, then `0x3f` when the guard started working, then `0x7e` again with the test corrected, and the unconfigured groups stayed at `0x3f` throughout, which is what says the offset now reaches the right register.

`port_isolate()` guards on `machine.max_port`, so it now declines the CPU port, which is one past that. `parse_isolate()` does accept the CPU port and `port_isolation_get()` has always returned 0 for it, so reading and writing disagreed and the write only landed by accident, with the top byte of the mask left over from an earlier register operation. This makes the two agree on refusing. Whether the CPU port ought to be isolatable is a separate question and I have not answered it here.

The remaining two are small. `rtl837x_leds.c:187` wrote an eight-port LED configuration on every machine and now writes it where the condition intended. The duplicate loop in `igmp_setup()` wrote the same value twice, which cost one redundant register write while the macro swallowed the body and would cost one per port now, so it goes.

Twenty nine bytes smaller than before on SWTGW218AS. No change to internal RAM or xdata. Built for KP_9000_6XHML_X2 as well.
