### PR TITLE
igmp: only hand reports to the CPU while snooping is on

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -1529,10 +1529,12 @@ void cmd_parser(void) __banked
 		} else if (cmd_compare(0, "igmp")) {
 			if (cmd_compare(1, "on"))
 				igmp_enable();
+			else if (cmd_compare(1, "off"))
+				igmp_setup();
 			else if (cmd_compare(1, "show"))
 				igmp_show();
 			else
-				igmp_setup();  // Reverts to default with IP-MC being flooded
+				print_string("Error: igmp on|off|show\n");
 		} else if (cmd_compare(0, "hostname")) {
 			/* "hostname" alone reports the current name; "hostname <text>"
 			 * sets it, sanitized to JSON-safe printable ASCII. A name with

--- a/rtl837x_igmp.c
+++ b/rtl837x_igmp.c
@@ -16,6 +16,7 @@
 #include "machine.h"
 
 extern __code struct machine machine;
+extern __xdata uint8_t igmpEnabled;
 
 #include "uip.h"
 
@@ -85,6 +86,7 @@ void igmp_setup(void) __banked
 {
 	uint8_t i;
 	print_string("igmp_setup called\n");
+	igmpEnabled = 0;
 	// For now, forward all unkown IP-MC pkts (2 bits per port. 00: flood via floodmask, 01: drop, 10: trap, 11: to rport)
 	REG_SET(RTL837X_IPV4_PORT_MC_LM_ACT, LOOKUP_MISS_FLOOD);
 	REG_SET(RTL837X_IPV6_PORT_MC_LM_ACT, LOOKUP_MISS_FLOOD);
@@ -130,6 +132,7 @@ void igmp_setup(void) __banked
 void igmp_enable(void) __banked
 {
 	print_string("igmp_enable called\n");
+	igmpEnabled = 1;
 	// Configure trapping of unhandled IGMP protocol packets to CPU
 	REG_SET(RTL837X_IGMP_TRAP_CFG, IGMP_CPU_PORT | IGMP_TRAP_PRIORITY);
 

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -121,6 +121,7 @@ __xdata uint16_t management_vlan;
 __xdata uint8_t tx_seq;
 
 __xdata uint8_t stpEnabled;
+__xdata uint8_t igmpEnabled;
 __xdata char hostname[24];	/* device hostname, default set at boot, see rtl837x_common.h */
 
 __code uint16_t bit_mask[16] = {
@@ -1152,7 +1153,7 @@ void handle_rx(void)
 				print_string("STP TX\n");
 				tcpip_output();
 			}
-		} else if (uip_buf[0] == 0x01 && uip_buf[1] == 0x00 && uip_buf[2] == 0x5e // IPv4-MC packet?
+		} else if (igmpEnabled && uip_buf[0] == 0x01 && uip_buf[1] == 0x00 && uip_buf[2] == 0x5e // IPv4-MC packet?
 			&& uip_buf[3] == 0x00 && uip_buf[4] == 0x00 && uip_buf[5] == 0x16) {
 			igmp_packet_handler();
 			if (uip_len) {


### PR DESCRIPTION
Following up on the offer in #327.

`handle_rx()` picked the IGMP branch on the destination address alone, so a report off the wire reached `igmp_packet_handler()` whether or not anyone had switched snooping on, and the handler goes straight to writing a table entry. The STP branch immediately above it is gated on `stpEnabled`, so this only brings IGMP into line with what is already there.

One thing I should have placed properly in #327: the `lacpEnabled && uip_buf[5] == 0x02` line I compared against lives in #299, not in main. On main the neighbouring gate is the STP one. Either way the point is the same, the branch next to it asks whether the feature is switched on and the IGMP branch does not.

Snooping state lives only in the per-port registers, and the receive path cannot afford a register read per packet, so the flag shadows it. `igmp_enable()` sets it and `igmp_setup()` clears it. Since `igmp_setup()` is both the "igmp off" path and the boot path, the flag starts out clear and follows the registers wherever they get set from.

Six bytes of BANK1 and one of xdata, no internal RAM. Built for SWTGW218AS on sdcc 4.5.0 and measured on one: `igmp on` sets the trap action on every port and the flag with it, `igmp off` clears both.

That last part only became true with #331, which is worth knowing if you take these in either order. Until then `igmp off` reached the per-port registers of nothing except one slot past the last port, so the trap action survived it and the flag was the only thing that actually stopped. The two changes are independent and do not touch the same lines, but they answer halves of the same question.

There is one thing I ran into while checking this, and you may want it before deciding how much the gate is worth: I do not think the handler can parse a report at all as it stands. `struct igmp_pkt` has no `struct vlan_tag`, while the other three receive structs in the tree do have one (`eth_in`, `arp_hdr_i`, `stp_pkt_in`). Everything past the RTL tag therefore sits four bytes early: `protocol` reads the low byte of the IP identification field, and `igmp_type` reads the first byte of the Router Alert option, which is never 0x12, 0x16 or 0x22. I took the offsets out of the generated assembly rather than working them out on paper.

That would also explain why the missing gate never turned into a symptom. I have not sent a patch for it, because so far I can only show that the parse is off, not that correcting the struct makes snooping work end to end.
