### PR TITLE
igmp: drop the duplicate port configuration loop

### DIFF
--- a/rtl837x_igmp.c
+++ b/rtl837x_igmp.c
@@ -96,11 +96,6 @@ void igmp_setup(void) __banked
 	// Enable lookup of IPv4 MC addresses in table
 	reg_bit_set(RTL837X_L2_CTRL, L2_CTRL_LUT_IPMC_HASH);
 
-	// Configure per-port IGMP configuration, bits 0-10 enable MC protocol snooping,
-	// bits 16-24 configure max MC group used by that port. For now all protocols are flooded (01)
-	for (i = machine.min_port; i <= machine.max_port; i++)
-		REG_SET(RTL837X_IGMP_PORT_CFG + (i << 2), 0x00ff7c15); 
-
 	/* Configure per-port IGMP operations when protocol messages are received
 	 * bits 0-9 enable MC protocol snooping
 	 * bit 10: Enable dynamic router port learning


### PR DESCRIPTION
Split out of #331, as you asked.

`igmp_setup()` writes the per-port IGMP configuration twice, once with the value spelled out and once assembled from the constants. `IGMP_MAX_GROUP | IGMP_PROTOCOL_ENABLE | IGMP_FLOOD` is exactly `0x00ff7c15`, so the two loops write the same thing. The second one carries the comment block explaining the bit layout, which is why the literal one is the one to drop.

This stands on its own against main and does not depend on the macro change. What the macro change does is make it worth doing: today the duplicate costs one redundant register write, because `REG_SET` is not a single statement and the unbraced loop body only ever reaches index `machine.max_port + 1`. With #331 in, the same duplicate costs one write per port on every boot and on every `igmp off`.

Fifty nine bytes of BANK1 on SWTGW218AS, nothing anywhere else. Built for SWTGW218AS and KP_9000_6XHML_X2 on sdcc 4.5.0.
