### PR TITLE
httpd: check the port index /counters.json is given

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -664,7 +664,16 @@ void httpd_appcall(void)
 				parse_short(q + 15);
 				send_vlan(short_parsed);
 			} else if (is_word(q, "/counters.json")) {
-				send_counters(q[20]-'0');
+				/* The port is one raw character of the request line and
+				 * indexes a nine entry table, so bound it here instead
+				 * of trusting the client to have sent a digit. Anything
+				 * below '0' wraps well past eight, so the one test
+				 * covers both ends. */
+				uint8_t cport = q[20] - '0';
+				if (cport > 8)
+					send_bad_request();
+				else
+					send_counters(cport);
 			} else if (is_word(q, "/eee.json")) {
 				send_eee();
 			} else if (is_word(q, "/bandwidth.json")) {


### PR DESCRIPTION
The handler takes one raw character out of the request line and hands it to send_counters(), which uses it to index machine.phys_to_log_port. That array has nine entries and the character is whatever the client sent, so the read can run up to 246 entries past the end, and whatever it finds goes on to STAT_GET as a port number. is_word() accepts any request whose name is followed by a question mark, so nothing forces the byte to be a digit.

I put the check where the byte is read, next to the assumption it protects, so it needs nothing from the machine description. sdcc leaves plain char unsigned and the subtraction wraps in eight bits, so anything below '0' comes out above 200 and one upper test covers both ends: only '0' through '8' reach send_counters. The compiled test is `add a,#0xf7` followed by `jnc`, which I read out of the assembly rather than assuming, and I ran all 256 byte values through it to confirm only 48 to 56 pass.

Out of range answers 400 through the same path the other malformed requests already take, rather than an empty array. An empty array would have been worse than nothing, since the statistics page calls BigInt on the first element before it checks the length. The page only ever asks for index zero up to the port count minus one, so nothing that answered before stops answering, and a non-200 reply makes its handler do nothing at all.

Costs 11 bytes of BANK1 and nothing in the common segment, BANK2, xdata or internal RAM. Built for SWTGW218AS and KP_9000_6XHML_X2 on sdcc 4.5.0.
