### PR TITLE
sfp: bound the wait for an I2C transfer

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1056,9 +1056,16 @@ uint8_t sfp_read_reg(uint8_t slot, uint8_t reg)
 	// Execute I2C Read
 	reg_bit_set(RTL837X_REG_I2C_CTRL, 0);
 
-	// Wait for execution to finish
+	/* Bound the wait. The bus runs to a module the switch does not control,
+	 * and this is reached from the main loop, so a module holding the clock
+	 * line stops packet handling, STP and the web interface with it. 0xff is
+	 * what the callers already treat as a failed transfer.
+	 */
+	uint16_t tries = 0;
 	do {
 		reg_read_m(RTL837X_REG_I2C_CTRL);
+		if (!++tries)
+			return 0xff;
 	} while (sfr_data[3] & 0x1);
 
 	reg_read_m(RTL837X_REG_I2C_OUT);


### PR DESCRIPTION
You closed #327 because the bounds in it were illusory: every one sat on an outer loop calling reg_read_m(), which ends in its own unlimited wait on the register bus, so the hang just moved down a level. That was right. I'm opening this one because I think it's the case that argument doesn't cover, and that's what I'd like you to judge it on.

sfp_read_reg() polls the I2C completion bit with no limit, and it's reached from handle_sfp(), which the main loop calls right before handle_rx(). A module holding the clock line therefore stops packet handling, STP and the web interface along with the read that provoked it, and plugging the module in is enough to start it. The bus runs to a part the switch doesn't control and that a user can plug in, which is what makes this different from a table operation nobody has ever seen get stuck.

What it doesn't fix, said plainly because a bound that only looks like one is worse than none: reg_read_m() keeps its unlimited wait, so an ASIC with a dead register interface still hangs below this. They are separate failures though. SFR_EXEC_STATUS settles inside the chip and doesn't depend on the state of an I2C transfer, so the register reads keep completing while the transfer doesn't. That's exactly the case a module can cause, and the one this bounds.

The wait gives up after 65536 polls and returns 0xff, which the callers already treat as a failed transfer: sfp_apply_quirks() reads that value as either a failed I2C read or a voltage the spec doesn't allow, and concludes the module has no diagnostics. The generated code loops on a 16 bit counter in r6 and r7 and leaves through `mov dpl,#0xff`, which I checked in the assembly.

The count isn't a tuned figure and I haven't measured what it costs in time, which matters: handle_sfp() does six reads for one insertion and I have no number for how long a read takes on this part. So a module that wedges the bus buys a bounded but possibly long pause rather than an instant answer. That beats never returning, but it isn't the same as being quick about it, and if you'd rather see a smaller count or a different failure value, say so and I'll change it.

Costs 31 bytes of the common segment and nothing in either bank, xdata or internal RAM. Built for SWTGW218AS and KP_9000_6XHML_X2 on sdcc 4.5.0. Not tested on hardware, since provoking it needs a module that misbehaves.
