### PR TITLE
port: pin the management MAC to the CPU port with a static L2 entry

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -48,6 +48,7 @@ __xdata uint16_t vlan_ptr;
 __xdata char port_names[9][PORT_NAME_SIZE];
 
 extern __xdata uint16_t management_vlan;
+extern __xdata struct uip_eth_addr uip_ethaddr;
 extern __xdata uint8_t sfp_speed[2];
 extern __xdata uint8_t sfp_pins_last;
 extern __xdata uint8_t sfp_options[2];
@@ -476,7 +477,9 @@ void parse_vlan(void)
 		vlan_settings.vlan = atoi_results_short;
 
 		if (cmd_compare(2, "mgmt")) {
+			port_l2_static_mgmt(uip_ethaddr.addr, management_vlan, true);
 			management_vlan = vlan_settings.vlan;
+			port_l2_static_mgmt(uip_ethaddr.addr, management_vlan, false);
 			if (!vlan_settings.vlan)
 				print_string("Management VLAN disabled\n");
 			else

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -911,3 +911,57 @@ bool port_ingress_vlan_filter_get(uint8_t port) __banked
 
 	return reg_bit_test(RTL837X_VLAN_PORT_IGR_FLTR, port);
 }
+
+// C1 bit 0: static (no aging); age at C3[4:2] must be non-zero or the
+// entry is invisible to lookup
+static void l2_mgmt_entry_fill(__xdata uint8_t *mac, __xdata uint16_t vlan)
+{
+	REG_WRITE(RTL837x_TBL_DATA_IN_A, mac[2], mac[3], mac[4], mac[5]);
+	REG_WRITE(RTL837x_TBL_DATA_IN_B, 0x20 | ((CPU_PORT & 0x3) << 6) | (vlan >> 8),
+		  vlan & 0xff, mac[0], mac[1]);
+	REG_WRITE(RTL837x_TBL_DATA_IN_C, 0x00, 0x01, 0x00, (7 << 2) | (CPU_PORT >> 2));
+}
+
+static void l2_mgmt_tbl_prepare(void)
+{
+	reg_read_m(RTL837x_TBL_DATA_0);
+	sfr_data[2] &= 0x3f;
+	sfr_data[1] &= 0xf8;
+	reg_write_m(RTL837x_TBL_DATA_0);
+}
+
+static void wait_table_ready(void)
+{
+	do {
+		reg_read(RTL837X_TBL_CTRL);
+	} while (SFR_DATA_0 & TBL_EXECUTE);
+}
+
+/** Pin the management MAC to the CPU port; remove_entry deletes it */
+void port_l2_static_mgmt(__xdata uint8_t *mac, __xdata uint16_t vlan, __xdata bool remove_entry) __banked
+{
+	wait_table_ready();
+
+	// vlan 0 = management VLAN disabled: untagged management resolves in
+	// VLAN 1; clients in other VLANs keep their learned entry and age as before
+	if (!vlan)
+		vlan = 1;
+	l2_mgmt_entry_fill(mac, vlan);
+	l2_mgmt_tbl_prepare();
+	if (remove_entry) {
+		// a search miss returns index 0, not a slot
+		REG_WRITE(RTL837X_TBL_CTRL, 0x00, 0x00, TBL_L2_UNICAST, TBL_EXECUTE);
+		wait_table_ready();
+		reg_read_m(RTL837x_TBL_DATA_0);
+		if (!(sfr_data[2] & 0x10))
+			return;
+		sfr_data[1] |= 0x04; // CLEAR-entry
+		reg_write_m(RTL837x_TBL_DATA_0);
+		__xdata uint16_t idx = (((uint16_t)sfr_data[2] & 0x0f) << 8) | sfr_data[3];
+		REG_WRITE(RTL837X_TBL_CTRL, idx >> 8, idx & 0xff, TBL_L2_UNICAST, TBL_WRITE | TBL_EXECUTE);
+	} else {
+		// method-0 write: the hardware hashes the key and places the entry
+		REG_WRITE(RTL837X_TBL_CTRL, 0x00, 0x00, TBL_L2_UNICAST, TBL_WRITE | TBL_EXECUTE);
+	}
+	wait_table_ready();
+}

--- a/rtl837x_port.h
+++ b/rtl837x_port.h
@@ -81,5 +81,6 @@ bool port_ingress_vlan_filter_get(uint8_t port) __banked;
 vlan_ingress_mode_t port_ingress_filter_get(__xdata uint8_t port) __banked;
 void port_isolate(uint8_t port, __xdata uint16_t pmask) __banked;
 uint16_t port_isolation_get(uint8_t port) __banked;
+void port_l2_static_mgmt(__xdata uint8_t *mac, __xdata uint16_t vlan, __xdata bool remove_entry) __banked;
 
 #endif

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -2306,6 +2306,8 @@ void main(void)
 	early_boot_handle_button();
 
 	execute_config();
+	// After the config so the entry lands in the final management VLAN
+	port_l2_static_mgmt(uip_ethaddr.addr, management_vlan, false);
 	/* After the config: a name from it wins, otherwise derive one. */
 	set_hostname_default();
 	print_cmd_prompt();


### PR DESCRIPTION
An idle switch eventually stops answering on its management IP. The CPU's own MAC exists in the L2 table only as a learned entry, created whenever the CPU transmits, and it ages out like any other dynamic entry. Unknown unicast is not flooded to the CPU port, so once the entry expires, frames for the management IP no longer reach the CPU until the next CPU transmission (usually an ARP reply) re-teaches it, and then it ages out again. Active web sessions keep the entry alive continuously, which is why this mostly goes unnoticed: it bites exactly when you have not touched the switch for a while and then cannot reach it.

The fix is a static entry for the management MAC on the CPU port, installed after the startup config has been replayed so it lands in the final management VLAN, and moved when the management VLAN is changed at runtime.

Getting the entry into the table took some reverse engineering, and the commit message records what was established on hardware: a table write with read-method 0 hashes the key in TBL_DATA_IN and places the entry itself, since a search returns index 0 on a miss and there is no software-visible insertion slot. The age field in the third data word must be non-zero or the entry is invisible to lookup entirely, and the static flag is bit 0 of byte 1 of that word: in a paired experiment an entry with the flag held full age indefinitely while an identical entry without it aged to invisible within the aging period. Note this is a different bit than the L2 status page currently decodes as static, so the pinned entry displays as learned; correcting that display would be a separate change.

Tested on a SWTGW218AS against current main: after eight minutes of enforced silence (well past the observed aging time, with the ARP entry pinned on the client so no broadcast could wake the CPU) the switch answered 20 of 20 unicast pings, where unpatched firmware loses nearly all of them. The same test passes after moving the management VLAN away and back at runtime, and the move leaves exactly one CPU entry in the table with no stale leftover.
