### PR TITLE
html: move the L2 table walk into a shared walkL2() helper

### DIFF
--- a/html/l2.js
+++ b/html/l2.js
@@ -1,7 +1,3 @@
-var l2GetInterval;
-var l2Entries = [];
-var l2CurrentEntry = 0;
-
 function fillStats() {
   var tbl = document.getElementById('statstable');
   if (!numPorts)
@@ -118,7 +114,6 @@ function fillL2(s)
   s = uniq(s);
   l2All = s;
   renderL2();
-  l2Entries = [];
 }
 
 function paintL2(tbl, s)
@@ -147,53 +142,20 @@ function paintL2(tbl, s)
 }
 
 function getL2() {
-  var xhttp = new XMLHttpRequest();
-  xhttp.onreadystatechange = function() {
-    if (this.readyState == 4 && this.status == 200) {
-      var s = JSON.parse(xhttp.responseText);
-      var s = s.map(function(e) { 
-        e.vlan = parseInt(e.vlan, 16);
-        e.idx = parseInt(e.idx, 16);
-        e.type = e.type == "s" ? t('l2_static') : t('l2_learned');
-        e.port = e.port == 9 ? 'CPU' : logToPhysPort[e.port];
-      return e;
-    });
-      l2Entries.push(...s);
-      if (l2Entries.length >= 4096) {
-        l2Entries = [];
-        l2CurrentEntry = 0;
-        clearInterval(l2GetInterval);
-        return;
-      }
-      if (!s.length) {
-        l2CurrentEntry = 0;
-        fillL2(l2Entries);
-        return;
-      }
-      var w = 0;
-      for (var i = l2Entries.length-1; i > 0; i--) {
-        if (l2Entries[0].idx == l2Entries[i].idx) {
-          w = 1;
-          break;
-        }
-      }
-      if (w) {
-        l2CurrentEntry = 0; 
-        fillL2(l2Entries);
-      } else {
-        l2CurrentEntry = s[s.length-1].idx + 1;
-      }
+  walkL2(function(entries, ok) {
+    if (ok) {
+      for (var i = 0; i < entries.length; i++)
+        entries[i].type = entries[i].type == "s" ? t('l2_static') : t('l2_learned');
+      fillL2(entries);
     }
-  };
-  xhttp.open("GET", "/l2.json?idx=" + l2CurrentEntry, true);
-  xhttp.timeout = 1500; sendXHTTP(xhttp);
+    setTimeout(getL2, 1000);
+  });
 }
 
 window.addEventListener("load", function() {
   update( () => {
     getL2();
     const interval = setInterval(update, 2000);
-    l2GetInterval = setInterval(getL2, 1000);
   });;
 });
 

--- a/html/l2.js
+++ b/html/l2.js
@@ -159,10 +159,15 @@ function getL2() {
       return e;
     });
       l2Entries.push(...s);
-      if (l2Entries >= 4096) {
+      if (l2Entries.length >= 4096) {
         l2Entries = [];
         l2CurrentEntry = 0;
         clearInterval(l2GetInterval);
+        return;
+      }
+      if (!s.length) {
+        l2CurrentEntry = 0;
+        fillL2(l2Entries);
         return;
       }
       var w = 0;

--- a/html/main.js
+++ b/html/main.js
@@ -285,3 +285,66 @@ function sendXHTTP(x)
   currentRequests.push(x);
 }
 
+
+function walkL2(onDone)
+{
+  var entries = [];
+  var idx = 0;
+  var tries = 0;
+
+  function retry() {
+    if (++tries < 3) {
+      setTimeout(page, 1000);
+      return;
+    }
+    onDone(entries, false);
+  }
+
+  function page() {
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+      if (this.readyState != 4)
+        return;
+      if (this.status != 200) {
+        retry();
+        return;
+      }
+      var s;
+      try {
+        s = JSON.parse(xhttp.responseText);
+      } catch (err) {
+        retry();
+        return;
+      }
+      tries = 0;
+      s = s.map(function(e) {
+        e.vlan = parseInt(e.vlan, 16);
+        e.idx = parseInt(e.idx, 16);
+        e.port = e.port == 9 ? 'CPU' : logToPhysPort[e.port];
+        return e;
+      });
+      if (!s.length) {
+        onDone(entries, true);
+        return;
+      }
+      entries.push(...s);
+      for (var i = entries.length - 1; i > 0; i--) {
+        if (entries[0].idx == entries[i].idx) {
+          onDone(entries, true);
+          return;
+        }
+      }
+      if (entries.length >= 4096) {
+        onDone(entries, true);
+        return;
+      }
+      idx = s[s.length - 1].idx + 1;
+      setTimeout(page, 1000);
+    };
+    xhttp.open("GET", "/l2.json?idx=" + idx, true);
+    xhttp.timeout = 1500;
+    sendXHTTP(xhttp);
+  }
+
+  page();
+}

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -356,6 +356,7 @@ void send_l2(uint16_t idx)
 	 */
 	__xdata uint16_t entry = idx & 0xfff;
 	__xdata uint16_t first_entry = 0xffff; // An illegal entry index
+	bool first = true;
 	char_to_html('[');
 	while (1) {
 		entries_left--;
@@ -369,9 +370,22 @@ void send_l2(uint16_t idx)
 		} while (sfr_data[3] & TBL_EXECUTE);
 
 		reg_read_m(RTL837x_L2_DATA_OUT_B);
-		if ((sfr_data[0] & 0x20)) {	// Check entry is valid
+		bool valid = (sfr_data[0] & 0x20) != 0;
+		if (valid) {
+			/* separator + 74-byte worst-case entry + closing "]" */
+			if (slen + 76 > TCP_OUTBUF_SIZE)
+				break;
+			if (!first)
+				char_to_html(',');
+			first = false;
+
+			// VLAN, taken from the read above instead of reading the register twice
+			slen += strtox(outbuf + slen, "{\"vlan\":\"");
+			charhex_to_html(sfr_data[0] & 0x0f);
+			byte_to_html(sfr_data[1]);
+
 			// MAC
-			slen += strtox(outbuf + slen, "{\"mac\":\"");
+			slen += strtox(outbuf + slen, "\",\"mac\":\"");
 			byte_to_html(sfr_data[2]); char_to_html(':');
 			byte_to_html(sfr_data[3]); char_to_html(':');
 			port = (sfr_data[0] >> 6) & 0x3;
@@ -380,12 +394,6 @@ void send_l2(uint16_t idx)
 			byte_to_html(sfr_data[1]); char_to_html(':');
 			byte_to_html(sfr_data[2]); char_to_html(':');
 			byte_to_html(sfr_data[3]);
-
-			// VLAN
-			slen += strtox(outbuf + slen, "\",\"vlan\":\"");
-			reg_read_m(RTL837x_L2_DATA_OUT_B);
-			charhex_to_html(sfr_data[0] & 0x0f);
-			byte_to_html(sfr_data[1]);
 
 			// type
 			reg_read_m(RTL837x_L2_DATA_OUT_C);
@@ -396,32 +404,26 @@ void send_l2(uint16_t idx)
 
 			port |= (sfr_data[3] & 0x3) << 2;
 			itoa_html(port);
+		}
 
-			// Index
-			reg_read_m(RTL837x_TBL_DATA_0);
-			entry = (((uint16_t)sfr_data[2] & 0x0f) << 8) | sfr_data[3];
+		// Index
+		reg_read_m(RTL837x_TBL_DATA_0);
+		entry = (((uint16_t)sfr_data[2] & 0x0f) << 8) | sfr_data[3];
+		if (valid) {
 			slen += strtox(outbuf + slen, ",\"idx\":\"");
 			byte_to_html(entry >> 8);
 			byte_to_html(entry);
 			char_to_html('"');
 			char_to_html('}');
-			entry += 1; // We want the next entry following after the current entry
-		} else {
-			reg_read_m(RTL837x_TBL_DATA_0);
-			entry = (((uint16_t)sfr_data[2] & 0x0f) << 8) | sfr_data[3] + 1;
 		}
-		if (first_entry == 0xffff) {
-			char_to_html(',');
+		entry += 1; // We want the next entry following after the current entry
+
+		if (first_entry == 0xffff)
 			first_entry = entry;
-		} else {
-			if (first_entry == entry || !entries_left) {
-				char_to_html(']');
-				break;
-			} else {
-				char_to_html(',');
-			}
-		}
+		else if (first_entry == entry || !entries_left)
+			break;
 	}
+	char_to_html(']');
 }
 
 


### PR DESCRIPTION
This is the main.js and l2.js half of what I sketched on #335, put up on its own as I offered there. @bloqaudio is holding that PR as a draft waiting for it, so that the port decoding of /l2.json lives in one place before trunk entries start turning up in that field.

It stacks on #340. The first two commits here are that PR and only the last one is new, so review just `html: move the L2 table walk into a shared walkL2() helper`. Once #340 lands this rebases down to that single commit. Happy to sit on it until then if reviewing both at once is awkward.

`walkL2(onDone)` pages through the table once, parses idx and vlan out of hex, maps the port to a physical number or to `'CPU'`, and calls `onDone(entries, ok)`. It stops on a wrapped index, an empty page or 4096 entries, all of which set `ok`. l2.js keeps the s and l to label mapping, since that one needs the page's translations, redraws only when `ok` is set, and restarts the walk from its own callback either way. ports.js in #335 would use the same helper with its 15 second gap, keeping the per port grouping there.

@bloqaudio, one difference from the sketch: the callback takes a second argument. `entries => devRender(entries)` still works unchanged, but you probably want to skip the redraw when `ok` is clear, for the reason in the third point below.

Three things change while moving, and they are the parts worth arguing about:

The next request goes out from the previous reply rather than from a `setInterval` that fires whether or not the last one came back. With one connection served at a time, a timer that outruns the responses only queues work it cannot use.

A walk that reaches 4096 entries now hands over what it collected. Before it dropped the entries and cleared its own interval, so the page could not refresh again until it was reloaded.

A page that comes back as anything other than 200, or with a body `JSON.parse` rejects, is asked for again at the same index, up to three times, and only then does the walk end with `ok` clear. That is not a new idea, it is the old behaviour written down: the previous code ignored a non 200 and let the interval ask for the same index again, so a blip never disturbed the table on screen. I had this ending the walk instead, until I read my own test output properly and saw that it meant every timeout redraws the page with a truncated table. At one connection at a time and a 1500 ms timeout that is not a rare event.

I drove the helper itself in node against a scripted server rather than testing a copy of it:

| case | entries | requests | asked for | ok |
|---|---|---|---|---|
| empty table | 0 | 1 | 0 | yes |
| three pages, last repeats index 0 | 61 | 3 | 0, 30, 60 | yes |
| empty page after one full page | 30 | 2 | 0, 30 | yes |
| 500, then a good page | 31 | 4 | 0, 30, 30, 31 | yes |
| malformed body, then a good page | 31 | 4 | 0, 30, 30, 31 | yes |
| three failures in a row | 30 | 4 | 0, 30, 30, 30 | no |
| 4096 entries in one page | 4096 | 1 | 0 | yes |
| CPU port | decodes to `'CPU'` | | | |
| vlan and idx | come back as numbers | | | |

main.js grows by 1331 bytes and l2.js loses 930, so 401 bytes of flash against main. Worth saying plainly where they land, because it is the part I would understand pushback on: nine pages pull in main.js, and exactly one of them walks the L2 table today, two once #335 lands. So seven or eight page loads now carry 1331 bytes they will not use, served by an httpd that does one connection at a time.

If that trade looks wrong, the alternative is a third file that only l2.html and ports.html include. I did not do that because main.js is where the sketch on #335 put it and where logToPhysPort and sendXHTTP already live, but it is a small change if you would rather.

Not tested on hardware yet.
