### PR TITLE
port: read a trunk's members through one function

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -250,8 +250,7 @@ void parse_lag(void)
 		print_string("LAG status:\n");
 		for (uint8_t i = 0; i < 4; i++) {
 			write_char(' '); write_char('1' + i);
-			reg_read_m(RTL837X_TRK_MBR_CTRL_BASE + (i << 2));
-			members = ((uint16_t)sfr_data[2]) << 8 | sfr_data[3]; 
+			members = port_lag_members_get(i);
 			if (!members) {
 				print_string(" disabled\n");
 				continue;

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -518,8 +518,7 @@ void send_lag(void)
 		slen += strtox(outbuf + slen, "{\"lagNum\":");
 		itoa_html(l);
 		slen += strtox(outbuf + slen, ",\"members\":\"");
-		reg_read_m(RTL837X_TRK_MBR_CTRL_BASE + (l << 2));
-		uint16_t ports = ((uint16_t)sfr_data[2] << 8) | sfr_data[3];
+		uint16_t ports = port_lag_members_get(l);
 		for (uint8_t i = 0; i < 16; i++) {
 			bool_to_html(!!(ports & 0x8000));
 			ports <<= 1;

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -734,6 +734,19 @@ void port_rldp_on(__xdata uint16_t p_ms)
 
 
 /*
+ * Reads the member port bitmask of a Link Aggregation Group.
+ * The groups have numbers 0-3; bit n is set when logical port n is a member.
+ * The bitmask reflects what the hardware holds, so it covers groups set up
+ * statically and groups a protocol brought up, without either having to say so.
+ */
+uint16_t port_lag_members_get(uint8_t lag) __banked
+{
+	reg_read(RTL837X_TRK_MBR_CTRL_BASE + (lag << 2));
+	return ((uint16_t)SFR_DATA_8 << 8) | SFR_DATA_0;
+}
+
+
+/*
  * Configure LAGs
  * Sets the members via port bitmask of a given Link Aggregation Group
  * The groups have numbers 0-3

--- a/rtl837x_port.h
+++ b/rtl837x_port.h
@@ -61,6 +61,7 @@ void port_mirror_set(register uint8_t port, __xdata uint16_t rx_pmask, __xdata u
 void port_mirror_del(void) __banked;
 bool port_ingress_filter(__xdata uint8_t port, __xdata vlan_ingress_mode_t type) __banked;
 void port_l2_setup(void) __banked;
+uint16_t port_lag_members_get(uint8_t lag) __banked;
 void port_lag_members_set(__xdata uint8_t lag, __xdata uint16_t members) __banked;
 void port_lag_hash_set(__xdata uint8_t lag, __xdata uint8_t hash) __banked;
 void port_eee_enable_all(__xdata uint8_t speed) __banked;


### PR DESCRIPTION
Small on its own, and the first piece of something larger, so let me say where it is going as well as what it does.

The member mask of an aggregation group lives in four registers at `RTL837X_TRK_MBR_CTRL_BASE`. Two places decode it by hand today, the `lag` command and the JSON behind the aggregation page, with the same two lines each, and a third writes it. My Spanning Tree work in #325 has a fourth copy of the decode, which is what made me look. `port_lag_members_get()` now sits next to `port_lag_members_set()`, the two readers call it, and the writer is untouched.

It answers from the hardware, so it covers a group configured with `lag` and a group a protocol brought up without either having to declare itself, which matters for the direction below.

No behaviour change. The expression is the one that was already written in both places, and neither caller depended on what the read left in `sfr_data`, since both go on to read the hash register next. 26 bytes of BANK1, 34 fewer of BANK2 and one byte of xdata for the banked parameter, so eight bytes less code in total. I read the generated assembly rather than assuming: the address still comes out as `0x4f38` plus the group shifted twice.

What it does not give is worth being blunt about, because the title could be read as more than it is. There is still no way to configure an aggregate as one interface. VLAN membership, PVID, egress tagging, ingress filtering, isolation, the learning constraint and MTU are all per physical port in this ASIC: the VLAN table holds a bitmask of physical ports, PVID sits at `PVID_BASE + ((port >> 1) << 2)`, the egress tag bits at `port << 1`, isolation and the learning constraint at `+ (port << 2)`. Nothing about a trunk exists at that level, so a trunk interface has to be a software layer, not a register.

Nor does this add a port to group map. `port_lag_members_get()` answers "who is in group N", not "which group is port N in".

The practical consequence of both, today: nothing stops a member of a working aggregate being given a different VLAN from its peers. The group then forwards asymmetrically depending on which member the hash picks, and no part of the firmware says a word about it.

As for how I would like to continue, there are three steps of which this is the first, and I would rather agree the shape with you than turn up with all of it at once.

**Second, a port to group lookup**, added when there is a consumer for it rather than before. #325 is that consumer: it keeps a private membership map and a private port to entity array purely because there was nothing shared to use. When that lands, it drops both and gets smaller.

**Third, the expansion layer**, which is the part that actually delivers a trunk interface. A command naming a group expands to the member mask before touching any register, membership changes re-apply the group's configuration to the port that joined or left, and the saved configuration stores the group form rather than one line per member. #325 already establishes that last pattern for the STP commands in `config.js`, so generalising it is extending something rather than inventing it. The open question there is what happens when a member is configured individually: refuse it, or accept it and re-sync the group.

If you would rather that whole direction stayed out of the tree, say so and I will keep it on my side and leave this PR as the plain deduplication it is, which stands on its own either way.
