### PR TITLE
httpd: mask the low byte of the table write, not byte two

### DIFF
--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -361,7 +361,7 @@ void send_l2(uint16_t idx)
 		entries_left--;
 		uint8_t port = 0;
 		reg_read_m(RTL837x_TBL_DATA_0);
-		REG_WRITE(RTL837x_TBL_DATA_0, sfr_data[0], sfr_data[1] & 0xfc, sfr_data[2] | (TBL_LUTREAD_NEXT_L2UC << 6), sfr_data[3]);
+		REG_WRITE(RTL837x_TBL_DATA_0, sfr_data[0], sfr_data[1], sfr_data[2] | (TBL_LUTREAD_NEXT_L2UC << 6), sfr_data[3] & 0xfc);
 
 		REG_WRITE(RTL837X_TBL_CTRL, entry >> 8, entry, TBL_L2_UNICAST, TBL_EXECUTE);
 		do {
@@ -438,7 +438,7 @@ void l2_delete(uint16_t idx)
 	slen += strtox(outbuf + slen, "{\"result\":");
 	// First, search for the entry based on the index
 	reg_read_m(RTL837x_TBL_DATA_0);
-	REG_WRITE(RTL837x_TBL_DATA_0, sfr_data[0], sfr_data[1] & 0xfc, sfr_data[2] | (TBL_LUTREAD_NEXT_L2UC << 6), sfr_data[3]);
+	REG_WRITE(RTL837x_TBL_DATA_0, sfr_data[0], sfr_data[1], sfr_data[2] | (TBL_LUTREAD_NEXT_L2UC << 6), sfr_data[3] & 0xfc);
 
 	REG_WRITE(RTL837X_TBL_CTRL, (idx >> 8) & 0xf, idx, TBL_L2_UNICAST, TBL_EXECUTE);
 	do {


### PR DESCRIPTION
@vDorst spotted this in #340. `REG_WRITE` fills `SFR_DATA_24` down to `SFR_DATA_0`, so `sfr_data[1] & 0xfc` clears bits 17:16 of `TBL_DATA_0` where 1:0 was meant. `send_l2()` and `l2_delete()` both have it.

Not tested on hardware, and I do not know what those bits do. If clearing 17:16 turns out to be deliberate, say so and I will close this.
