### PR TITLE
lag: number the groups from one and bound what the command is given

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -273,7 +273,9 @@ void parse_lag(void)
 
 	if (cmd_words_len < 2 || !isnumber(cmd_buffer[cmd_words_b[1]]))
 		goto err;
-	group = cmd_buffer[cmd_words_b[1]] - '0';
+	group = cmd_buffer[cmd_words_b[1]] - '1';
+	if (group > 3)		/* '0' wraps well past three, so one test does both ends */
+		goto err;
 
 	uint8_t w = 2;
 	while (w < cmd_words_len) {
@@ -283,7 +285,9 @@ void parse_lag(void)
 			port = cmd_buffer[cmd_words_b[w]] - '1';
 			if (isnumber(cmd_buffer[cmd_words_b[w] + 1]))
 				port = (port + 1) * 10 + cmd_buffer[cmd_words_b[w] + 1] - '1';
-				port = machine.phys_to_log_port[port];
+			if (port > 8)	/* phys_to_log_port holds nine entries */
+				goto err;
+			port = machine.phys_to_log_port[port];
 		} else {
 			goto err;
 		}
@@ -295,7 +299,7 @@ void parse_lag(void)
 	port_lag_members_set(group, members);
 	return;
 err:
-	print_string("Error: lag <lag> [port]...\n");
+	print_string("Error: lag <1-4> [port]...\n");
 }
 
 
@@ -304,7 +308,11 @@ void parse_lag_hash(void)
 	__xdata uint8_t group;
 	__xdata uint8_t hash = 0;
 
-	group = cmd_buffer[cmd_words_b[1]] - '0';
+	if (cmd_words_len < 2 || !isnumber(cmd_buffer[cmd_words_b[1]]))
+		goto err;
+	group = cmd_buffer[cmd_words_b[1]] - '1';
+	if (group > 3)		/* '0' wraps well past three, so one test does both ends */
+		goto err;
 
 	uint8_t w = 2;
 	while (w < cmd_words_len) {
@@ -330,6 +338,9 @@ void parse_lag_hash(void)
 		w++;
 	}
 	port_lag_hash_set(group, hash);
+	return;
+err:
+	print_string("Error: lag hash <1-4> [type]...\n");
 }
 
 

--- a/doc/link_aggregation.md
+++ b/doc/link_aggregation.md
@@ -92,7 +92,7 @@ The following shows the network configuration
 On _both_ switches create a LAG with ports 1 and 2 inside and the default hash algorithm which takes
 source and destination ports into account, e.g. just use the default:
 ```
-> lag 0 1 2
+> lag 1 1 2
 ```
 
 

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -356,7 +356,7 @@ void send_l2(uint16_t idx)
 	 */
 	__xdata uint16_t entry = idx & 0xfff;
 	__xdata uint16_t first_entry = 0xffff; // An illegal entry index
-	bool first = true;
+	__bit first = true;
 	char_to_html('[');
 	while (1) {
 		entries_left--;
@@ -370,7 +370,7 @@ void send_l2(uint16_t idx)
 		} while (sfr_data[3] & TBL_EXECUTE);
 
 		reg_read_m(RTL837x_L2_DATA_OUT_B);
-		bool valid = (sfr_data[0] & 0x20) != 0;
+		__bit valid = (sfr_data[0] & 0x20) != 0;
 		if (valid) {
 			/* separator + 74-byte worst-case entry + closing "]" */
 			if (slen + 76 > TCP_OUTBUF_SIZE)

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -758,7 +758,7 @@ void port_lag_members_set(__xdata uint8_t lag, __xdata uint16_t members) __banke
 	print_string("port_lag_members_set, lag: "); print_byte(lag); print_string(", members: "); print_short(members);
 	write_char('\n');
 	if (lag > 3) {
-		print_string("Link aggregation group must be 0-3!\n");
+		print_string("Link aggregation group out of range\n");
 		return;
 	}
 	reg_read_m(RTL837X_TRK_HASH_CTRL_BASE + (lag << 2));
@@ -777,8 +777,10 @@ void port_lag_hash_set(__xdata uint8_t lag, __xdata uint8_t hash_bits) __banked
 {
 	print_string("port_lag_hash_set, lag: "); print_byte(lag); print_string(", hash: "); print_byte(hash_bits);
 	write_char('\n');
-	if (lag > 3)
-		print_string("Link aggregation group must be 0-3!\n");
+	if (lag > 3) {
+		print_string("Link aggregation group out of range\n");
+		return;
+	}
 	REG_WRITE(RTL837X_TRK_HASH_CTRL_BASE + (lag << 2), 0, 0, 0, hash_bits);
 }
 


### PR DESCRIPTION
`lag show` has always printed the groups as 1 to 4 while `lag <n>` took the number literally, so typing what you saw configured the group beside it. Both `lag` and `lag hash` count from one now, matching how ports are numbered everywhere else, and reject anything outside 1 to 4.

Two bounds go in with it. The port argument indexed `machine.phys_to_log_port`, which holds nine entries, before it was checked, and a two digit argument reaches 109. And `port_lag_members_set()` and `port_lag_hash_set()` complained about a group out of range and then wrote the registers anyway, past the four the groups occupy; they return now. `lag hash` also read `cmd_words_b[1]` without checking a word was there.

Worth knowing before merging: a saved `lag 1 ...` line moves from hardware group 1 to group 0. Nothing behaves differently, `show` reports it as 1 either way now, but a register dump taken across the change will look like the group shifted.

Not tested on hardware.
