### PR TITLE
port: let a pvid name an aggregation group

### DIFF
--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -87,10 +87,9 @@ vlan_ingress_mode_t port_ingress_filter_get(__xdata uint8_t port) __banked
 /*
  * Define a Primary VLAN ID for a port 
 */
-void port_pvid_set(uint8_t port, __xdata uint16_t pvid) __banked
+static void port_pvid_write(uint8_t port, __xdata uint16_t pvid)
 {
 	// r4e1c:00001001 R4e1c-000017d0 r6738:00000000 R6738-00000000 (no filtering)
-	print_string("\nport_pvid_set called \n");
 	uint16_t reg = RTL837x_PVID_BASE_REG + ((port >> 1) << 2);
 
 	reg_read_m(reg);
@@ -99,6 +98,22 @@ void port_pvid_set(uint8_t port, __xdata uint16_t pvid) __banked
 	} else {
 		REG_WRITE(reg, sfr_data[0], sfr_data[1], sfr_data[2] & 0xf0 | (pvid >> 8), pvid);
 	}
+}
+
+void port_pvid_set(uint8_t port, __xdata uint16_t pvid) __banked
+{
+	uint8_t lag = port_lag_of(port);
+
+	print_string("\nport_pvid_set called \n");
+	if (lag == PORT_LAG_NONE) {
+		port_pvid_write(port, pvid);
+		return;
+	}
+
+	uint16_t members = port_lag_members_get(lag);
+	for (uint8_t i = 0; i < 10; i++)
+		if ((members >> i) & 1)
+			port_pvid_write(i, pvid);
 }
 
 uint16_t port_pvid_get(uint8_t port) __banked
@@ -743,6 +758,14 @@ uint16_t port_lag_members_get(uint8_t lag) __banked
 {
 	reg_read(RTL837X_TRK_MBR_CTRL_BASE + (lag << 2));
 	return ((uint16_t)SFR_DATA_8 << 8) | SFR_DATA_0;
+}
+
+uint8_t port_lag_of(uint8_t port) __banked
+{
+	for (uint8_t lag = 0; lag < 4; lag++)
+		if ((port_lag_members_get(lag) >> port) & 1)
+			return lag;
+	return PORT_LAG_NONE;
 }
 
 

--- a/rtl837x_port.h
+++ b/rtl837x_port.h
@@ -62,6 +62,8 @@ void port_mirror_del(void) __banked;
 bool port_ingress_filter(__xdata uint8_t port, __xdata vlan_ingress_mode_t type) __banked;
 void port_l2_setup(void) __banked;
 uint16_t port_lag_members_get(uint8_t lag) __banked;
+#define PORT_LAG_NONE 0xff
+uint8_t port_lag_of(uint8_t port) __banked;
 void port_lag_members_set(__xdata uint8_t lag, __xdata uint16_t members) __banked;
 void port_lag_hash_set(__xdata uint8_t lag, __xdata uint8_t hash) __banked;
 void port_eee_enable_all(__xdata uint8_t speed) __banked;


### PR DESCRIPTION
@logicog In #347 I set out three steps towards treating an aggregate as one interface, and said the second of them, a port to group lookup, would come when something in the tree needed it. Looking back at that, I had it the wrong way round. Both callers we have ask which ports are in a group, and that is the part which landed. Nothing asks which group a port is in, so a standalone patch for the lookup would have added a function with no caller. It only earns its place next to something that uses it, so here it is with one.

The problem it fixes is real today. VLAN membership, PVID, egress tagging, ingress filtering, isolation, the learning constraint and MTU are all per physical port in this ASIC, and nothing stops a member of a working group being given a different PVID from its peers. The group then forwards asymmetrically depending on which member the hash picks, with no part of the firmware saying a word about it.

PVID is the smallest of those settings, so it is the one I brought. A port outside a group keeps the path it had. A port inside one now applies to the whole group, which also means the saved configuration replays the same way whichever member it names.

The open question is what the rest should do. My inclination is the same shape for the others, and for a member configured individually to be accepted and applied to the group rather than refused, since refusing turns an ordinary command into an error for reasons the user cannot see. Say if you would rather it refused, or would rather the whole direction stayed out of the tree.

Built for SWTGW218AS and KP_9000_6XHML_X2 on sdcc 4.5.0. Not run on hardware.
