### PR TITLE
port: reject the CPU port in isolate instead of refusing it silently

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -428,11 +428,11 @@ void parse_isolate(void)
 
 	print_string("\nISOLATE ");
 
-	__xdata int8_t port_configured = cmd_buffer[cmd_words_b[1]] - '1';
-	port_configured = machine.phys_to_log_port[port_configured];
-	if (isnumber(cmd_buffer[cmd_words_b[1] + 1]))  // CPU-port, logical port 9
-		port_configured = (port_configured + 1) * 10 + cmd_buffer[cmd_words_b[1] + 1] - '1';
-	if (port_configured < 0 || port_configured > 9)
+	if (!isnumber(cmd_buffer[cmd_words_b[1]]) || cmd_buffer[cmd_words_b[1]] == '0'
+	    || isnumber(cmd_buffer[cmd_words_b[1] + 1]))
+		goto err;
+	__xdata uint8_t port_configured = machine.phys_to_log_port[cmd_buffer[cmd_words_b[1]] - '1'];
+	if (port_configured < machine.min_port || port_configured > machine.max_port)
 		goto err;
 
 	print_byte(port_configured); write_char('\n');


### PR DESCRIPTION
This is the parser side of #334.

`parse_isolate()` took a two digit port and mapped it to logical port 9, the CPU port, while `port_isolate()` and `port_isolation_get()` both refuse anything above `machine.max_port`. Setting the isolation of the CPU port was declined without a word, and reading it always answered no members whatever the hardware held. @vDorst settled the direction in the issue: the CPU port should not be named by hand, so the parser now bounds it to the front panel.

The digit is checked before it indexes `phys_to_log_port[]` as well. `isolate x show` used to read well past that table.

I left the member list alone. It still takes `10` for the CPU port and `isolate <port> off` sets that bit on purpose, so dropping the manual form there means every isolate has to add the bit by itself. #326 rewrites that loop anyway.