### PR TITLE
httpd: read the static flag of an L2 entry from the byte that holds it

### DIFF
--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -397,7 +397,7 @@ void send_l2(uint16_t idx)
 
 			// type
 			reg_read_m(RTL837x_L2_DATA_OUT_C);
-			if (sfr_data[2] & 0x1)
+			if (sfr_data[1] & 0x1)
 				slen += strtox(outbuf + slen, "\",\"type\":\"s\",\"port\":");
 			else
 				slen += strtox(outbuf + slen, "\",\"type\":\"l\",\"port\":");


### PR DESCRIPTION
The MAC table listing has never shown a static entry: it tests bit 0 of byte 2 of the third table data word, but the flag lives in bit 0 of byte 1. Byte 2 reads zero for learned and static entries alike, so every entry has always been listed as learned.

The evidence comes from the hardware sessions behind #343. An entry written with byte 1 bit 0 set survives the aging engine indefinitely where an identical entry without it ages to invisible within the aging period, and it reads back with exactly that bit set through both the address and the next-entry read methods. With this one line changed, the pinned entry from #343 lists as type s while the learned entries around it still list as type l, which as far as I can tell is the first time this firmware has displayed a static entry at all.
