### PR TITLE
cmd_parser: reject port 0 in the ingress command

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -529,7 +529,7 @@ void parse_ingress(void)
 			if (!isnumber(p)) {
 				continue;
 			}
-			if (p - '1' > 9) {
+			if (p < '1') {
 				print_string("Invalid physical port number: "); write_char(p); write_char('\n');
 				continue;
 			}


### PR DESCRIPTION
The single-digit arm of the ingress parser guards with p - '1' > 9, which no digit can satisfy: the largest, '9', gives 8. The digit that needed rejecting is '0', which gives -1 and indexes one byte before phys_to_log_port, so "ingress 0 t" reads out of bounds and applies the ingress mode to whatever port number that byte happens to contain. Ports are 1-based, so reject anything below '1'; values above '9' are already excluded by the digit check before this.

Found by running cppcheck over the tree with the SDCC keywords defined away, and verified on a SWTGW218AS: the command now answers "Invalid physical port number: 0" where it previously misconfigured silently.
