### PR TITLE
Makefile - don't always rebuild/relink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,12 @@ $(VERSION_HEADER):
 	@printf '%s\n' "#ifndef VERSION_H" "#define VERSION_H" \
 		"#define VERSION_SW \"$(VERSION_EXTENSION)\"" \
 		"#define BUILD_DATE \"$(BUILD_DATE)\"" \
-		"#endif" > $(VERSION_HEADER)
+		"#endif" > $(VERSION_HEADER).tmp
+	@if ! cmp -s $(VERSION_HEADER).tmp $(VERSION_HEADER) 2>/dev/null; then \
+		mv $(VERSION_HEADER).tmp $(VERSION_HEADER); \
+	else \
+		rm -f $(VERSION_HEADER).tmp; \
+	fi
 
 httpd: html_data.h
 

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ $(BUILDDIR)/rtlplayground-$(FILENAME_EXTENSION).bin: $(BUILDDIR)/rtlplayground.i
 	tools/output/crc_calculator -u $@
 	ln -sf $(MACHINE)/rtlplayground-$(FILENAME_EXTENSION).bin output/rtlplayground.bin
 
-.PHONY: clean all $(SUBDIRS) $(VERSION_HEADER) create_build_dir
+.PHONY: clean all $(SUBDIRS) create_build_dir
 
 .PHONY:
 machine_check:

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ $(BUILDDIR)/rtlplayground-$(FILENAME_EXTENSION).bin: $(BUILDDIR)/rtlplayground.i
 	tools/output/imagebuilder -i $^ $@
 	tools/output/fileadder -a $(DEFAULT_CONFIG_LOCATION) -s $(IMAGESIZE) -d config.txt $@
 	tools/output/fileadder -a $(CONFIG_LOCATION) -s $(IMAGESIZE) -d config.txt $@
-	tools/output/fileadder -a $(HTML_LOCATION) -s $(IMAGESIZE) -d html -p html_data -b BANK1 $@
+	tools/output/fileadder -a $(HTML_LOCATION) -s $(IMAGESIZE) -d html -b BANK1 $@
 	tools/output/crc_calculator -u $@
 	ln -sf $(MACHINE)/rtlplayground-$(FILENAME_EXTENSION).bin output/rtlplayground.bin
 


### PR DESCRIPTION
Makefile now handles generated files correctly.
PR is marked as draft, because `fileadder` tool needs some reworking to handle `-p` argument properly.  