### PR TITLE
leds: move the SWTG018AS-V2.1.0 custom LED init to BANK2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ create_build_dir:
 # Keep machine.c in first position to fail immediately on invalid $MACHINE value
 SRCS = \
 	machine.c \
+	machine_init.c \
 	cmd_editor.c \
 	cmd_parser.c \
 	dhcp.c \
@@ -142,6 +143,7 @@ machine_check:
 	do \
 	echo "Checking $${MACHINE}"; \
 	$(CC) $(CC_FLAGS) -DMACHINE_$${MACHINE} -MMD -o $(BUILDDIR)/tmp/machine_check -c machine.c; \
+	$(CC) $(CC_FLAGS) -DMACHINE_$${MACHINE} -MMD -o $(BUILDDIR)/tmp/machine_check -c machine_init.c; \
 	done
 	@rm -rf $(BUILDDIR)/tmp
 

--- a/machine.c
+++ b/machine.c
@@ -42,8 +42,6 @@ __code const struct machine machine = {
 		    },
 };
 
-void machine_custom_init(void) { }
-
 #elif defined MACHINE_KP_9000_6XH_X
 __code const struct machine machine = {
 	.machine_name = "keepLink KP-9000-6XH-X",
@@ -71,8 +69,6 @@ __code const struct machine machine = {
 			0 },
 		    },
 };
-
-void machine_custom_init(void) { }
 
 #elif defined MACHINE_KP_9000_6XH_X2
 __code const struct machine machine = {
@@ -122,10 +118,6 @@ __code const struct machine machine = {
 		},
 	};
 
-void machine_custom_init(void) {
-	reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
-}
-
 #elif defined MACHINE_KP_9000_9XH_X_EU
 __code const struct machine machine = {
 	.machine_name = "keepLink KP-9000-9XH-X-EU",
@@ -150,8 +142,6 @@ __code const struct machine machine = {
 			LEDS_2G5 | LEDS_LINK | LEDS_ACT },
 		    },
 };
-
-void machine_custom_init(void) { }
 
 #elif defined MACHINE_KP_9000_9XHML_X_V2_2
 __code const struct machine machine = {
@@ -204,8 +194,6 @@ __code const struct machine machine = {
 	},
 };
 
-void machine_custom_init(void) { }
-
 #elif defined MACHINE_KP_9000_9XHML_X_V3_1
 __code const struct machine machine = {
 	.machine_name = "keepLink KP-9000-9XHML-X V3.1",
@@ -240,8 +228,6 @@ __code const struct machine machine = {
 				0x11, 0x0e, 0x14, 0x11, 0x12, 0x15, 0x15, 0x16, 0x18, 0x19,
 				0x1a, 0x19, 0x1d, 0x1e, 0x1c, 0x1d, 0x20, 0x21},
 };
-
-void machine_custom_init(void) { }
 
 #elif defined MACHINE_SWGT024_V2_0_MANAGED
 __code const struct machine machine = {
@@ -284,8 +270,6 @@ __code const struct machine machine = {
 	},
 };
 
-void machine_custom_init(void) { }
-
 #elif defined MACHINE_SWGT024_V2_0_UNMANAGED
 __code const struct machine machine = {
 	.machine_name = "SWGT024 V2.0 Unmanaged",
@@ -327,8 +311,6 @@ __code const struct machine machine = {
 	},
 };
 
-void machine_custom_init(void) { }
-
 #elif defined MACHINE_SWTG018AS_A_V_2_0
 __code const struct machine machine = {
 	.machine_name = "SWTG018AS-A V2.0",
@@ -368,8 +350,6 @@ __code const struct machine machine = {
 		     0x1d, 0x20, 0x21 },
 };
 
-void machine_custom_init(void) { }
-
 #elif defined MACHINE_HG0402XG_V1_1
 __code const struct machine machine = {
 	.machine_name = "HG0402XG V1.1",
@@ -408,8 +388,6 @@ __code const struct machine machine = {
 		    },
 };
 
-void machine_custom_init(void) { }
-
 #elif defined MACHINE_SWTGW218AS
 
 __code const struct machine machine = {
@@ -442,8 +420,6 @@ __code const struct machine machine = {
 				  }, // unused		    	},
 				},
 };
-
-void machine_custom_init(void) { }
 
 #elif defined MACHINE_PCB_SWTG018AS_V2_1_0 // Sold as Sodola SL902 / Horaco "SWTGW218AS"; the SWTGW218AS label also covers other PCBs with different SFP and LED wiring (see MACHINE_SWTGW218AS)
 
@@ -487,44 +463,6 @@ __code const struct machine machine = {
 		     0x1d, 0x20, 0x21 },
 };
 
-// The LED-set encoding cannot express this board's bi-color SFP LED (green <= 2.5G,
-// blue at 10G), so program the LED register block with the values the stock firmware
-// uses. Runs after leds_setup() and overrides the values computed there.
-// The final entry routes the blue-LED pin to the LED controller via PIN_MUX_0;
-// as a GPIO (the default) no LED register can light it. PIN_MUX_1/2 stay
-// untouched so SFP detect (GPIO38) and i2c remain GPIOs.
-static __code const struct { uint16_t reg; uint32_t val; } custom_init_regs[] = {
-	{ 0x6520, 0x0023e430UL },   // LED_MODE
-	{ 0x6524, 0xff001400UL },   // LED3_0_SET3
-	{ 0x6528, 0x00100000UL },   // LED3_0_SET1
-	{ 0x652c, 0x007f013fUL },   // LED3_2_SET3
-	{ 0x6530, 0x02000400UL },   // LED1_0_SET3
-	{ 0x6534, 0x01400141UL },   // LED3_2_SET2
-	{ 0x6538, 0x01440170UL },   // LED1_0_SET2
-	{ 0x653c, 0x18000041UL },   // LED3_2_SET1
-	{ 0x6540, 0x01400155UL },   // LED1_0_SET1
-	{ 0x6544, 0x01411000UL },   // LED3_2_SET0
-	{ 0x6548, 0x01740141UL },   // LED1_0_SET0
-	{ 0x654c, 0x00010000UL },   // LED_PORT_SET_SEL
-	{ 0x65d8, 0x3ffb6dffUL },   // LED_GLB_ACTIVE
-	{ 0x65dc, 0x7f24977fUL },   // LED_GLB_IO_EN
-	{ 0x65e0, 0x08144040UL },   // LED_GLB_MUX_1
-	{ 0x65e4, 0x10349309UL },   // LED_GLB_MUX_2
-	{ 0x65e8, 0x12454391UL },   // LED_GLB_MUX_3
-	{ 0x65ec, 0x19616555UL },   // LED_GLB_MUX_4
-	{ 0x65f0, 0x1c79d65aUL },   // LED_GLB_MUX_5
-	{ 0x65f4, 0x0002181dUL },   // LED_GLB_MUX_6
-	{ 0x7f8c, 0x20db6880UL },   // PIN_MUX_0
-};
-
-void machine_custom_init(void) {
-	uint8_t i;
-	// REG_SET is a multi-statement macro without a do-while wrapper: braces required
-	for (i = 0; i < sizeof(custom_init_regs) / sizeof(custom_init_regs[0]); i++) {
-		REG_SET(custom_init_regs[i].reg, custom_init_regs[i].val);
-	}
-}
-
 #elif defined MACHINE_LIANGUO_ZX_SWTGW215AS // Has PCB branded PCB-SWTG115AS-V2.0 but is labeled and reports as a ZX-SWTGW215AS, seems to be identical to the "real" ZX-SWTGW215AS except for the LEDs
 __code const struct machine machine = {
 	.machine_name = "Lianguo ZX-SWTGW215AS",
@@ -557,8 +495,6 @@ __code const struct machine machine = {
 	.led_mux_custom = 0,
 };
 
-void machine_custom_init(void) { }
-
 #elif defined MACHINE_DEFAULT_8C_1SFP
 __code const struct machine machine = {
 	.machine_name = "8+1 SFP Port Switch",
@@ -583,8 +519,6 @@ __code const struct machine machine = {
 			LEDS_2G5 | LEDS_LINK | LEDS_ACT },
 		    },
 };
-
-void machine_custom_init(void) { }
 
 #elif defined MACHINE_TRENDNET_TEG_S562
 __code const struct machine machine = {
@@ -624,8 +558,6 @@ __code const struct machine machine = {
 	},
 
 };
-
-void machine_custom_init(void) { }
 
 #elif defined(MACHINE_PCB_K0402WS_V3) || defined(MACHINE_HI_K0402WS)  // Sold as a variety of devices, see doc/
 __code const struct machine machine = {
@@ -673,10 +605,6 @@ __code const struct machine machine = {
 		},
 	};
 
-void machine_custom_init(void) { 
-	reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
-}
-
 #elif defined MACHINE_K0501W_V2_0
 __code const struct machine machine = {
 	.machine_name = "K0501W V2.0",
@@ -710,8 +638,6 @@ __code const struct machine machine = {
 		},
 	 },
 };
-
-void machine_custom_init(void) { }
 
 #elif defined MACHINE_ZX310S_4T2XH
 __code const struct machine machine = {
@@ -755,8 +681,6 @@ __code const struct machine machine = {
 		      }
 		    },
 };
-
-void machine_custom_init(void) { }
 
 #elif defined MACHINE_STEAMEMO_IG204_V1
 __code const struct machine machine = {
@@ -808,8 +732,6 @@ __code const struct machine machine = {
 	},
 };
 
-void machine_custom_init(void) { }
-
 #elif defined MACHINE_HI_K0801WS
 __code const struct machine machine = {
     .machine_name = "Hi-Source HI-k0801WS",
@@ -858,8 +780,6 @@ __code const struct machine machine = {
         },
     },
 };
-
-void machine_custom_init(void) { }
 
 #elif defined MACHINE_FNS1200P
 __code const struct machine machine = {
@@ -916,11 +836,6 @@ __code const struct machine machine = {
     },
 };
 
-void machine_custom_init(void)
-{
-    reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
-}
-
 
 #elif defined MACHINE_PCB_SWTG024AS_A_2_0_1
 __code const struct machine machine = {
@@ -970,14 +885,6 @@ __code const struct machine machine = {
             },
     };
 
-void machine_custom_init(void)
-{
-    reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
-    reg_bit_set(RTL837X_REG_LED_MODE, 17);
-    reg_bit_clear(RTL837X_REG_LED_MODE, 9);
-    reg_bit_clear(RTL837X_REG_LED_MODE, 7);
-}
-
 #elif defined MACHINE_SWTG024AS_A_2_0_1_5C_1SFP
 __code const struct machine machine = {
     .machine_name = "SWTG024AS-A-V2.0.1-5C-1SFP",
@@ -1020,25 +927,6 @@ __code const struct machine machine = {
                             0x00,0x01,0x04,0x05,0x08,0x09,0x0c,0x3f,0x0d,0x10,0x11,0x0e,0x14,0x11,0x12,0x15,0x15,0x16,0x18,0x19,0x1a,0x19,0x1d,0x1e,0x1c,0x1d,0x20,0x21
             },
     };
-
-void machine_custom_init(void)
-{
-    uint16_t pval;
-
-    reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
-    reg_bit_set(RTL837X_REG_LED_MODE, 17);
-    reg_bit_clear(RTL837X_REG_LED_MODE, 9);
-    reg_bit_clear(RTL837X_REG_LED_MODE, 7);
-
-    // OEM firmware sets these companion SDS0 polarity bits for the RTL8221B.
-    sds_read(0, 0, 0);
-    pval = SFR_DATA_U16;
-    sds_write_v(0, 0, 0, pval | 0x100);
-
-    sds_read(0, 6, 2);
-    pval = SFR_DATA_U16;
-    sds_write_v(0, 6, 2, pval | 0x4000);
-}
 
 #elif defined MACHINE_SWTG024AS_V2_0
 __code const struct machine machine = {
@@ -1083,25 +971,6 @@ __code const struct machine machine = {
             },
     };
 
-void machine_custom_init(void)
-{
-    uint16_t pval;
-
-    reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
-    reg_bit_set(RTL837X_REG_LED_MODE, 17);
-    reg_bit_clear(RTL837X_REG_LED_MODE, 9);
-    reg_bit_clear(RTL837X_REG_LED_MODE, 7);
-
-    // OEM firmware sets these companion SDS0 polarity bits for the RTL8221B.
-    sds_read(0, 0, 0);
-    pval = SFR_DATA_U16;
-    sds_write_v(0, 0, 0, pval | 0x100);
-
-    sds_read(0, 6, 2);
-    pval = SFR_DATA_U16;
-    sds_write_v(0, 6, 2, pval | 0x4000);
-}
-
 #elif defined MACHINE_ZX310S_4T2XT
 __code const struct machine machine = {
 	.machine_name = "ZX310S_4T2XT",
@@ -1138,12 +1007,6 @@ __code const struct machine machine = {
 		      }
 		    },
 };
-
-void machine_custom_init(void) {
-	// For this device, the reset value of RTL837X_PIN_MUX_0 is 0x30000000,
-	// which would disables all LEDS, enable them manually:
-	REG_SET(RTL837X_PIN_MUX_0, 0x30db68bf);
-}
 
 #elif defined MACHINE_FG_4GT_2SX_V2_0
 __code const struct machine machine = {
@@ -1210,10 +1073,6 @@ __code const struct machine machine = {
 				0x1a, 0x1d, 0x1d, 0x1e, 0x1e, 0x20, 0x21, 0x22
 		},
 	};
-
-void machine_custom_init(void) {
-	REG_SET(RTL837X_REG_LED_GLB_IO_EN, 0x7624155b);
-}
 
 #else
 	#error "Please select a machine type in machine.h"

--- a/machine.h
+++ b/machine.h
@@ -95,6 +95,6 @@ typedef struct machine_runtime
 	uint8_t isN : 1;
 };
 
-void machine_custom_init(void);
+void machine_custom_init(void) __banked;
 
 #endif

--- a/machine_init.c
+++ b/machine_init.c
@@ -20,34 +20,15 @@ void machine_custom_init(void) __banked
 }
 
 #elif defined MACHINE_PCB_SWTG018AS_V2_1_0
-// The LED-set encoding cannot express this board's bi-color SFP LED (green <= 2.5G,
-// blue at 10G), so program the LED register block with the values the stock firmware
-// uses. Runs after leds_setup() and overrides the values computed there.
-// The final entry routes the blue-LED pin to the LED controller via PIN_MUX_0;
-// as a GPIO (the default) no LED register can drive it. PIN_MUX_1/2 stay
-// untouched so SFP detect (GPIO38) and i2c remain GPIOs.
+// Stock-firmware values for what the LED-set encoding cannot express: the
+// bi-color SFP LED (blue pin at 10G) and the PIN_MUX_0 routing of that pin
+// to the LED controller. Runs after leds_setup(), which covers the rest.
 static __code const struct { uint16_t reg; uint32_t val; } custom_init_regs[] = {
-	{ 0x6520, 0x0023e430UL },   // LED_MODE
-	{ 0x6524, 0xff001400UL },   // LED3_0_SET3
-	{ 0x6528, 0x00100000UL },   // LED3_0_SET1
-	{ 0x652c, 0x007f013fUL },   // LED3_2_SET3
-	{ 0x6530, 0x02000400UL },   // LED1_0_SET3
-	{ 0x6534, 0x01400141UL },   // LED3_2_SET2
-	{ 0x6538, 0x01440170UL },   // LED1_0_SET2
-	{ 0x653c, 0x18000041UL },   // LED3_2_SET1
-	{ 0x6540, 0x01400155UL },   // LED1_0_SET1
-	{ 0x6544, 0x01411000UL },   // LED3_2_SET0
-	{ 0x6548, 0x01740141UL },   // LED1_0_SET0
-	{ 0x654c, 0x00010000UL },   // LED_PORT_SET_SEL
-	{ 0x65d8, 0x3ffb6dffUL },   // LED_GLB_ACTIVE
-	{ 0x65dc, 0x7f24977fUL },   // LED_GLB_IO_EN
-	{ 0x65e0, 0x08144040UL },   // LED_GLB_MUX_1
-	{ 0x65e4, 0x10349309UL },   // LED_GLB_MUX_2
-	{ 0x65e8, 0x12454391UL },   // LED_GLB_MUX_3
-	{ 0x65ec, 0x19616555UL },   // LED_GLB_MUX_4
-	{ 0x65f0, 0x1c79d65aUL },   // LED_GLB_MUX_5
-	{ 0x65f4, 0x0002181dUL },   // LED_GLB_MUX_6
-	{ 0x7f8c, 0x20db6880UL },   // PIN_MUX_0
+	{ RTL837X_REG_LED3_0_SET1,   0x00100000UL },
+	{ RTL837X_REG_LED1_0_SET1,   0x01400155UL },
+	{ RTL837X_REG_LED1_0_SET0,   0x01740141UL },
+	{ RTL837X_REG_LED_GLB_IO_EN, 0x7f24977fUL },
+	{ RTL837X_PIN_MUX_0,         0x20db6880UL },
 };
 
 void machine_custom_init(void) __banked

--- a/machine_init.c
+++ b/machine_init.c
@@ -1,0 +1,139 @@
+/*
+ * Per-machine one-shot boot hooks, hosted in BANK2 so board-specific
+ * tables and code do not consume the common bank.
+ */
+#include <stdint.h>
+#include "machine.h"
+#include "rtl837x_pins.h"
+#include "rtl837x_leds.h"
+#include "rtl837x_sfr.h"
+#include "rtl837x_regs.h"
+#include "rtl837x_common.h"
+
+#pragma codeseg BANK2
+#pragma constseg BANK2
+
+#if defined MACHINE_KP_9000_6XH_X2
+void machine_custom_init(void) __banked
+{
+	reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
+}
+
+#elif defined MACHINE_PCB_SWTG018AS_V2_1_0
+// The LED-set encoding cannot express this board's bi-color SFP LED (green <= 2.5G,
+// blue at 10G), so program the LED register block with the values the stock firmware
+// uses. Runs after leds_setup() and overrides the values computed there.
+// The final entry routes the blue-LED pin to the LED controller via PIN_MUX_0;
+// as a GPIO (the default) no LED register can drive it. PIN_MUX_1/2 stay
+// untouched so SFP detect (GPIO38) and i2c remain GPIOs.
+static __code const struct { uint16_t reg; uint32_t val; } custom_init_regs[] = {
+	{ 0x6520, 0x0023e430UL },   // LED_MODE
+	{ 0x6524, 0xff001400UL },   // LED3_0_SET3
+	{ 0x6528, 0x00100000UL },   // LED3_0_SET1
+	{ 0x652c, 0x007f013fUL },   // LED3_2_SET3
+	{ 0x6530, 0x02000400UL },   // LED1_0_SET3
+	{ 0x6534, 0x01400141UL },   // LED3_2_SET2
+	{ 0x6538, 0x01440170UL },   // LED1_0_SET2
+	{ 0x653c, 0x18000041UL },   // LED3_2_SET1
+	{ 0x6540, 0x01400155UL },   // LED1_0_SET1
+	{ 0x6544, 0x01411000UL },   // LED3_2_SET0
+	{ 0x6548, 0x01740141UL },   // LED1_0_SET0
+	{ 0x654c, 0x00010000UL },   // LED_PORT_SET_SEL
+	{ 0x65d8, 0x3ffb6dffUL },   // LED_GLB_ACTIVE
+	{ 0x65dc, 0x7f24977fUL },   // LED_GLB_IO_EN
+	{ 0x65e0, 0x08144040UL },   // LED_GLB_MUX_1
+	{ 0x65e4, 0x10349309UL },   // LED_GLB_MUX_2
+	{ 0x65e8, 0x12454391UL },   // LED_GLB_MUX_3
+	{ 0x65ec, 0x19616555UL },   // LED_GLB_MUX_4
+	{ 0x65f0, 0x1c79d65aUL },   // LED_GLB_MUX_5
+	{ 0x65f4, 0x0002181dUL },   // LED_GLB_MUX_6
+	{ 0x7f8c, 0x20db6880UL },   // PIN_MUX_0
+};
+
+void machine_custom_init(void) __banked
+{
+	uint8_t i;
+	// REG_SET is a multi-statement macro without a do-while wrapper: braces required
+	for (i = 0; i < sizeof(custom_init_regs) / sizeof(custom_init_regs[0]); i++) {
+		REG_SET(custom_init_regs[i].reg, custom_init_regs[i].val);
+	}
+}
+
+#elif defined(MACHINE_PCB_K0402WS_V3) || defined(MACHINE_HI_K0402WS)
+void machine_custom_init(void) __banked
+{
+	reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
+}
+
+#elif defined MACHINE_FNS1200P
+void machine_custom_init(void) __banked
+{
+    reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
+}
+
+#elif defined MACHINE_PCB_SWTG024AS_A_2_0_1
+void machine_custom_init(void) __banked
+{
+    reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
+    reg_bit_set(RTL837X_REG_LED_MODE, 17);
+    reg_bit_clear(RTL837X_REG_LED_MODE, 9);
+    reg_bit_clear(RTL837X_REG_LED_MODE, 7);
+}
+
+#elif defined MACHINE_SWTG024AS_A_2_0_1_5C_1SFP
+void machine_custom_init(void) __banked
+{
+    uint16_t pval;
+
+    reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
+    reg_bit_set(RTL837X_REG_LED_MODE, 17);
+    reg_bit_clear(RTL837X_REG_LED_MODE, 9);
+    reg_bit_clear(RTL837X_REG_LED_MODE, 7);
+
+    // OEM firmware sets these companion SDS0 polarity bits for the RTL8221B.
+    sds_read(0, 0, 0);
+    pval = SFR_DATA_U16;
+    sds_write_v(0, 0, 0, pval | 0x100);
+
+    sds_read(0, 6, 2);
+    pval = SFR_DATA_U16;
+    sds_write_v(0, 6, 2, pval | 0x4000);
+}
+
+#elif defined MACHINE_SWTG024AS_V2_0
+void machine_custom_init(void) __banked
+{
+    uint16_t pval;
+
+    reg_bit_set(RTL837X_REG_LED_GLB_IO_EN, 6);
+    reg_bit_set(RTL837X_REG_LED_MODE, 17);
+    reg_bit_clear(RTL837X_REG_LED_MODE, 9);
+    reg_bit_clear(RTL837X_REG_LED_MODE, 7);
+
+    // OEM firmware sets these companion SDS0 polarity bits for the RTL8221B.
+    sds_read(0, 0, 0);
+    pval = SFR_DATA_U16;
+    sds_write_v(0, 0, 0, pval | 0x100);
+
+    sds_read(0, 6, 2);
+    pval = SFR_DATA_U16;
+    sds_write_v(0, 6, 2, pval | 0x4000);
+}
+
+#elif defined MACHINE_ZX310S_4T2XT
+void machine_custom_init(void) __banked
+{
+	// For this device, the reset value of RTL837X_PIN_MUX_0 is 0x30000000,
+	// which would disables all LEDS, enable them manually:
+	REG_SET(RTL837X_PIN_MUX_0, 0x30db68bf);
+}
+
+#elif defined MACHINE_FG_4GT_2SX_V2_0
+void machine_custom_init(void) __banked
+{
+	REG_SET(RTL837X_REG_LED_GLB_IO_EN, 0x7624155b);
+}
+
+#else
+void machine_custom_init(void) __banked { }
+#endif

--- a/rtl837x_stp.c
+++ b/rtl837x_stp.c
@@ -14,6 +14,11 @@
 #include "uip.h"
 #include "machine.h"
 
+// All entry points are __banked and nothing here runs from an interrupt,
+// so the module does not need to stay in the resident bank
+#pragma codeseg BANK2
+#pragma constseg BANK2
+
 extern __code struct machine machine;
 extern __xdata uint8_t sfr_data[4];
 


### PR DESCRIPTION
Fixes #361.

main currently fails to link for MACHINE_PCB_SWTG018AS_V2_1_0:

```
Error: Bank 0: code segment too large at 0x4000!
```

Bank 0 ends at 0x4066, 102 bytes past the limit. The machine's custom LED register table and its init loop live in machine.c, whose code and constants go to the common bank. The machine built and was validated when #317 was submitted; main has grown since, and the machine_check target compiles each machine but never links, so the overflow stayed invisible until an image build.

The first commit generalizes the fix as suggested in review: machine_custom_init() runs once at boot, so all the per-machine hooks move to a new machine_init.c compiled into BANK2, and the prototype becomes banked. No machine's init code or tables consume bank 0 any more, and machine_check compiles the new file per machine.

The second commit shrinks the table: measured against what the generic leds_setup() computes on this board, eight of the 21 stock values are identical to the generic result and eight more can revert to it with no change in LED behaviour at any tested link state. The five that remain each do something: 6528 selects blue over green at 10G, 6540 and 6548 carry the SFP and copper LED set behaviour, 65dc enables the LED outputs, and PIN_MUX_0 routes the blue-LED pin to the LED controller.

Bank 0 closes with 94 bytes free. Verified from a clean boot on a SWTG018AS-V2.1.0 board: copper green with activity blink at 2.5G, SFP green at 2.5G with a 2.5G module, SFP blue at 10G with a 10G module, LEDs off on link down.

A machine_check variant that also links each machine would catch this class of breakage in CI; happy to look at that as a follow-up if there is interest.