### PR TITLE
Use SFR_DATA_U32 in REG_SET()

### DIFF
--- a/rtl837x_regs.h
+++ b/rtl837x_regs.h
@@ -308,7 +308,7 @@
 #ifdef REGDBG
 
 #define REG_SET(r, v) do { \
-	SFR_DATA_U16_UPPER = (uint16_t)(v >> 16); \
+	SFR_DATA_U16_UPPER = (uint16_t)((uint32_t)(v) >> 16); \
 	SFR_DATA_U16 = (uint16_t)(v); \
 	reg_write(r); \
 	write_char('R'); print_byte(r >> 8); print_byte(r); write_char('-'); \
@@ -324,8 +324,9 @@
 	write_char('R'); print_byte(r>>8); print_byte(r); write_char('-'); print_byte(v24); print_byte(v16); print_byte(v8); print_byte(v0); write_char(' '); \
 } while (0)
 #else
+
 #define REG_SET(r, v) do { \
-	SFR_DATA_U16_UPPER = (uint16_t)(v >> 16); \
+	SFR_DATA_U16_UPPER = (uint16_t)((uint32_t)(v) >> 16); \
 	SFR_DATA_U16 = (uint16_t)(v); \
 	reg_write(r); \
 } while (0)

--- a/rtl837x_regs.h
+++ b/rtl837x_regs.h
@@ -308,10 +308,7 @@
 #ifdef REGDBG
 
 #define REG_SET(r, v) do { \
-	SFR_DATA_24 = (((uint32_t)v) >> 24) & 0xff; \
-	SFR_DATA_16 = (((uint32_t)v) >> 16) & 0xff; \
-	SFR_DATA_8 = (((uint16_t)v) >> 8 & 0xff); \
-	SFR_DATA_0 = (v) & 0xff; \
+	SFR_DATA_U32 = v; \
 	reg_write(r); \
 	write_char('R'); print_byte(r >> 8); print_byte(r); write_char('-'); \
 	print_byte(((v) >> 24) & 0xff); print_byte((v) >> 16 & 0xff); print_byte((v) >> 8 & 0xff); print_byte( (v) & 0xff); write_char(' '); \
@@ -327,10 +324,7 @@
 } while (0)
 #else
 #define REG_SET(r, v) do { \
-	SFR_DATA_24 = (((uint32_t)v) >> 24) & 0xff; \
-	SFR_DATA_16 = (((uint32_t)v) >> 16) & 0xff; \
-	SFR_DATA_8 = (((uint16_t)v) >> 8 & 0xff); \
-	SFR_DATA_0 = (v) & 0xff; \
+	SFR_DATA_U32 = v; \
 	reg_write(r); \
 } while (0)
 

--- a/rtl837x_regs.h
+++ b/rtl837x_regs.h
@@ -308,7 +308,8 @@
 #ifdef REGDBG
 
 #define REG_SET(r, v) do { \
-	SFR_DATA_U32 = v; \
+	SFR_DATA_U16_UPPER = (uint16_t)(v >> 16); \
+	SFR_DATA_U16 = (uint16_t)(v); \
 	reg_write(r); \
 	write_char('R'); print_byte(r >> 8); print_byte(r); write_char('-'); \
 	print_byte(((v) >> 24) & 0xff); print_byte((v) >> 16 & 0xff); print_byte((v) >> 8 & 0xff); print_byte( (v) & 0xff); write_char(' '); \
@@ -324,7 +325,8 @@
 } while (0)
 #else
 #define REG_SET(r, v) do { \
-	SFR_DATA_U32 = v; \
+	SFR_DATA_U16_UPPER = (uint16_t)(v >> 16); \
+	SFR_DATA_U16 = (uint16_t)(v); \
 	reg_write(r); \
 } while (0)
 


### PR DESCRIPTION
While improving #368, I saw that using `SFR_DATA_U32` directly, gives better code.

Somehow the compiler seems to generate way better code which saves +300 bytes.

eg.storing zeros to SFR_DATA-registers.

Instead of 4x 3-byte instructions = 12 bytes. 
CPU-cycles: 4x 3 = 12 cycles.
```c
SFR_DATA_24 = 0x00;
SFR_DATA_16 = 0x00;
SFR_DATA_8 = 0x00;
SFR_DATA_0 = 0x00;
```

It uses 1 + 4x 2-bytes instructions = 9 bytes.
CPU-cycles: 1 + 4x 2  = 9 cycles.
```c
clr a;
SFR_DATA_24 = a;
SFR_DATA_16 = a;
SFR_DATA_8 = a;
SFR_DATA_0 = a;
```

So it saves on bytes and runtime.