### PR TITLE
httpd: buffer a plain POST body that arrives after the headers

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -62,6 +62,12 @@ __xdata uint8_t verify_crc;
 __xdata uint32_t max_upload;
 __xdata uint16_t short_parsed;
 
+#define POSTBODY_CMD	1
+#define POSTBODY_LOGIN	2
+#define POSTBODY_TIMEOUT (5 * SYS_TICK_HZ)
+__xdata uint8_t postbody_endpoint;
+__xdata uint16_t postbody_start;
+
 __xdata char passwd[21];
 // Set when a verified firmware upload awaits its response ACK, after
 // which the chip resets to apply the staged image
@@ -78,6 +84,7 @@ __xdata uint32_t last_session_use;
 #define TSTATE_CLOSED 		3
 #define TSTATE_POST 		4
 #define TSTATE_MULTIPART	5
+#define TSTATE_POSTBODY		6
 
 extern __xdata uint16_t crc_value;
 __xdata uint16_t crc_final;
@@ -265,6 +272,18 @@ void send_to_login(void)
 void send_unauthorized(void)
 {
 	slen = strtox(outbuf, "HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+}
+
+
+void send_length_required(void)
+{
+	slen = strtox(outbuf, "HTTP/1.1 411 Length Required\r\nConnection: close\r\n\r\n");
+}
+
+
+void send_ok(void)
+{
+	slen = strtox(outbuf, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n");
 }
 
 
@@ -559,7 +578,7 @@ static void handle_config_fragment(__xdata uint8_t *p)
 		send_bad_request();
 		return;
 	}
-	slen = strtox(outbuf, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n");
+	send_ok();
 }
 
 
@@ -604,11 +623,94 @@ static void handle_firmware_fragment(__xdata uint8_t *p)
 }
 
 
+static void run_cmd_body(__xdata uint8_t *body)
+{
+	execute_commands(body);
+	if (err_status != ERR_OK) {
+		send_bad_request();
+		return;
+	}
+	send_ok();
+}
+
+
+static void run_login_body(__xdata uint8_t *body)
+{
+	if (strstart(body, "pwd=") && is_url_word_x(body + 4, passwd)) {
+		dbg_string("Password accepted!\n");
+		read_reg_timer(&last_session_use);
+		gen_random_hex_chars(session_id, SESSION_ID_LENGTH);
+		session_id[SESSION_ID_LENGTH] = NUL;
+		slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nConnection: close\r\nLocation: index.html\r\n" \
+				      "Set-Cookie: session=");
+		for (uint8_t i = 0; i < SESSION_ID_LENGTH; i++)
+			outbuf[slen++] = session_id[i];
+		slen += strtox(outbuf + slen, "; SameSite=Strict\r\n\r\n");
+	} else {
+		dbg_string("Password invalid!\n");
+		slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nConnection: close\r\nLocation: login.html\r\n\r\n");
+	}
+}
+
+
+static uint8_t post_body_take(__xdata uint8_t *p)
+{
+	uint16_t have;
+
+	if (!content_length) {
+		send_length_required();
+		return 0;
+	}
+	if (content_length >= CONFIG_UPLOAD_BUF) {
+		send_bad_request();
+		return 0;
+	}
+	have = uip_len - (p - uip_appdata);
+	if (have >= content_length) {
+		p[content_length] = NUL;
+		return 1;
+	}
+	memcpy(config_buf, p, have);
+	pre_acc = have;
+	postbody_start = ticks;
+	uip_conn->appstate.tstate = TSTATE_POSTBODY;
+	return 0;
+}
+
+
+static void post_body_continue(void)
+{
+	uint16_t take;
+
+	// no header scan runs while the body is pending: content_length is this request's
+	take = content_length - pre_acc;
+	if (take > uip_len)
+		take = uip_len;
+	memcpy(config_buf + pre_acc, uip_appdata, take);
+	pre_acc += take;
+	if (pre_acc < content_length) {
+		postbody_start = ticks;
+		return;
+	}
+	config_buf[pre_acc] = NUL;
+	uip_conn->appstate.tstate = TSTATE_NONE;
+	if (postbody_endpoint == POSTBODY_CMD)
+		run_cmd_body(config_buf);
+	else
+		run_login_body(config_buf);
+}
+
+
 void handle_post(void)
 {
 	__xdata struct httpd_state * __xdata s = &(uip_conn->appstate);
 	__xdata uint8_t *p = uip_appdata;
 	__xdata uint8_t *request_path = p + 6;
+
+	if (s->tstate == TSTATE_POSTBODY) {
+		post_body_continue();
+		return;
+	}
 
 	// Was the multipart header sent in multiple packets?
 	if (s->tstate != TSTATE_MULTIPART) {
@@ -662,11 +764,11 @@ void handle_post(void)
 			send_unauthorized();
 			return;
 		}
-		execute_commands(p);
-		if (err_status != ERR_OK) {
-			send_bad_request();
+		postbody_endpoint = POSTBODY_CMD;
+		if (!post_body_take(p))
 			return;
-		}
+		run_cmd_body(p);
+		return;
 	} else if (is_word(request_path, "login")) {
 		dbg_string("POST login\n");
 
@@ -676,21 +778,11 @@ void handle_post(void)
 			return;
 		}
 
-		p += 8; // Read also over "pwd="
-		if (is_url_word_x(p, passwd)) {
-			dbg_string("Password accepted!\n");
-			read_reg_timer(&last_session_use);
-			gen_random_hex_chars(session_id, SESSION_ID_LENGTH);
-			session_id[SESSION_ID_LENGTH] = NUL;
-			slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nConnection: close\r\nLocation: index.html\r\n" \
-					      "Set-Cookie: session=");
-			for (uint8_t i = 0; i < SESSION_ID_LENGTH; i++)
-				outbuf[slen++] = session_id[i];
-			slen += strtox(outbuf + slen, "; SameSite=Strict\r\n\r\n");
-		} else {
-			dbg_string("Password invalid!\n");
-			slen = strtox(outbuf, "HTTP/1.1 302 Found\r\nConnection: close\r\nLocation: login.html\r\n\r\n");
-		}
+		p += 4;
+		postbody_endpoint = POSTBODY_LOGIN;
+		if (!post_body_take(p))
+			return;
+		run_login_body(p);
 		return;
 	} else if (s->tstate == TSTATE_MULTIPART || is_word(request_path, "upload") || is_word(request_path, "config")) {
 		dbg_string("POST upload/config request\n");
@@ -712,8 +804,6 @@ void handle_post(void)
 		send_not_found();
 		return;
 	}
-	slen = strtox(outbuf, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n");
-	return;
 }
 
 
@@ -743,6 +833,11 @@ void httpd_appcall(void)
 		if (s->tstate == TSTATE_ACKED) {
 			dbg_string("Closing because everything has been transmitted\n");
 			uip_close();
+			s->tstate = TSTATE_CLOSED;
+		} else if (s->tstate == TSTATE_POSTBODY
+			   && (uint16_t)ticks - postbody_start > POSTBODY_TIMEOUT) {
+			dbg_string("Body never arrived\n");
+			uip_abort();
 			s->tstate = TSTATE_CLOSED;
 		}
 	} else if (uip_acked() && s->tstate == TSTATE_TX) {
@@ -811,10 +906,12 @@ void httpd_appcall(void)
 		dbg_char('\n');
 #endif
 		p = uip_appdata;
-		if (is_word(p, "POST") || s->tstate == TSTATE_MULTIPART) {
+		if (is_word(p, "POST") || s->tstate == TSTATE_MULTIPART
+		    || s->tstate == TSTATE_POSTBODY) {
 			handle_post();
 			// If this is an ongoing post stream, then wait for the next packet
-			if (s->tstate == TSTATE_POST || s->tstate == TSTATE_MULTIPART) {
+			if (s->tstate == TSTATE_POST || s->tstate == TSTATE_MULTIPART
+			    || s->tstate == TSTATE_POSTBODY) {
 				uip_len = 0;
 				return;
 			}

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -231,7 +231,10 @@ uint8_t parse_short(__xdata uint8_t *p)
 		c = *p++ - '0';
 		if (c > 9) { break; }
 		err = 0;
-		short_parsed = (short_parsed * 10) + c;
+		if (short_parsed > 6552)
+			short_parsed = 0xffff;
+		else
+			short_parsed = (short_parsed * 10) + c;
 	}
 	return err;
 }

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -54,6 +54,7 @@ __xdata uint8_t config_buf[CONFIG_UPLOAD_BUF];
 __xdata uint16_t pre_acc;
 __xdata uint8_t * __xdata content_type = 0;
 __xdata uint8_t * __xdata session = 0;
+__xdata uint16_t content_length;
 
 // Global variables holding POST state
 __xdata uint16_t bindex; // Current index into the boundary
@@ -272,6 +273,7 @@ __xdata uint8_t *scan_header(__xdata uint8_t * __xdata p)
 	__xdata uint8_t *v;
 
 	content_type = 0;
+	content_length = 0;
 	session = 0;
 	authenticated = 0;
 
@@ -282,7 +284,10 @@ __xdata uint8_t *scan_header(__xdata uint8_t * __xdata p)
 		p++;
 		if ((v = header_value(p, "\ncontent-type:")))
 			content_type = v;
-		else if ((v = header_value(p, "\ncookie:"))) {
+		else if ((v = header_value(p, "\ncontent-length:"))) {
+			parse_short(v);
+			content_length = short_parsed;
+		} else if ((v = header_value(p, "\ncookie:"))) {
 			/* Scan for the "session" key: the header may hold several
 			 * cookies in any order. Match "session" not "session=" -
 			 * is_word() requires a separator after the match and '=' is

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -138,6 +138,24 @@ bool is_word(__xdata uint8_t *xdata_str_p, __code uint8_t * __xdata code_str_p)
 }
 
 
+/* name must be lower-case, starting with the '\n' of the previous line's end */
+__xdata uint8_t *header_value(__xdata uint8_t *p, __code uint8_t *name)
+{
+	uint8_t u, c;
+
+	while ((c = *name++)) {
+		u = *p++;
+		if (u >= 'A' && u <= 'Z')
+			u += 'a' - 'A';
+		if (u != c)
+			return 0;
+	}
+	while (*p == ' ' || *p == '\t')
+		p++;
+	return p;
+}
+
+
 bool is_url_word_x(__xdata uint8_t *uri_str_p, __xdata uint8_t *src_str_p)
 {
 	uint8_t u, s;
@@ -248,28 +266,29 @@ void send_unauthorized(void)
 
 __xdata uint8_t *scan_header(__xdata uint8_t * __xdata p)
 {
+	__xdata uint8_t *v;
+
 	content_type = 0;
 	session = 0;
 	authenticated = 0;
 
-	while (*p != '\r' || *(p + 1) != '\n' || *(p + 2) != '\r' || *(p + 3) != '\n') {
+	while (!strstart(p, "\r\n\r\n")) {
 		dbg_char(*p);
 		if (!*p++)
 			break;
-		if (is_word(p, "\nContent-Type:"))
-			content_type = p + 15;
-		else if (is_word(p, "\nCookie:")) {
+		if ((v = header_value(p, "\ncontent-type:")))
+			content_type = v;
+		else if ((v = header_value(p, "\ncookie:"))) {
 			/* Scan for the "session" key: the header may hold several
 			 * cookies in any order. Match "session" not "session=" -
 			 * is_word() requires a separator after the match and '=' is
 			 * one, so this also rejects a longer key like "sessionx". */
-			__xdata uint8_t *c = p + 8;	/* past "\nCookie:" */
-			while (*c && *c != '\r' && *c != '\n') {
-				if (is_word(c, "session")) {
-					session = c + 8;	/* past "session=" */
+			while (*v && *v != '\r' && *v != '\n') {
+				if (is_word(v, "session")) {
+					session = v + 8;	/* past "session=" */
 					break;
 				}
-				c++;
+				v++;
 			}
 		}
 	}

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -277,8 +277,9 @@ __xdata uint8_t *scan_header(__xdata uint8_t * __xdata p)
 
 	while (!strstart(p, "\r\n\r\n")) {
 		dbg_char(*p);
-		if (!*p++)
+		if (!*p)
 			break;
+		p++;
 		if ((v = header_value(p, "\ncontent-type:")))
 			content_type = v;
 		else if ((v = header_value(p, "\ncookie:"))) {


### PR DESCRIPTION
Found while reviewing #329: a `POST /cmd` whose body arrives in a separate TCP segment from the headers executes nothing, because `handle_post()` reads the body from the segment that carried the request line. The endpoint still answers as if it succeeded, so every scripted command becomes a silent no-op. Python's urllib and requests both write headers and body separately, which makes this the default experience for exactly the clients most likely to script `/cmd`. `/login` has the same hole. The multipart endpoints were fixed in #356 and #359; this covers the plain ones.

Five commits, the first three standalone fixes the review turned up:

1. **httpd: match header field names case-insensitively.** New `header_value()`: lower-case name anchored at the line start, request bytes folded as compared, value returned past any blanks. `content-type:` and `Content-Type:multipart/...` were both silently treated as absent before.
2. **httpd: saturate `parse_short()` instead of wrapping.** `?vid=65540` read as VLAN 4.
3. **httpd: keep `scan_header()` on the terminator of a truncated header.** The scan stepped over the NUL, so the end-of-header check read a stale byte.
4. **httpd: parse `Content-Length` in `scan_header()`**, through `parse_short()`.
5. **httpd: buffer a plain POST body that arrives after the headers.** When the first segment holds fewer body bytes than announced, the bytes accumulate in `config_buf` (idle outside multipart uploads) and the connection waits in `TSTATE_POSTBODY`; once complete, the endpoint runs against the buffer. The `/cmd` and `/login` executions move into `run_cmd_body()` and `run_login_body()`, which share `send_ok()` with the config path, and `run_login_body()` checks the `pwd=` prefix instead of skipping four bytes blindly. The announced length is the contract on both paths: a body that arrives with the headers is terminated at `Content-Length`, so pipelined bytes are no longer executed as commands; no usable `Content-Length` answers `411`; a length at or above the buffer answers `400`. The wait state aborts the connection after five seconds without progress, measured on the system tick, so headers followed by silence (including on the unauthenticated `/login`) cannot hold the single uIP slot.

**Memory:** internal RAM is byte for byte identical to `main` on `PCB_SWTG018AS_V2_1_0` and `SWTGW218AS`; xdata grows by 5 bytes and code by 783. `make machine_check` passes for all machines.

**Tested** on a SWTG018AS V2.1.0 board with a scripted client that controls the segmentation (25 cases plus the two hold cases, re-run in full on the current head):

- split login accepted and refused correctly, and a login body without the `pwd=` prefix refused
- `/cmd` split after the headers, and with the body itself split three ways
- `Content-Length` with no space, lower-case, and with a tab
- trailing bytes past the announced length ignored in both shapes
- no, zero and unparseable `Content-Length` answer `411`
- overlong commands split either way answer `400`
- an announcement beyond the buffer and an unauthenticated `/cmd` are refused at once without waiting for a body
- a truncated header answers `404`
- headers-then-silence on `/login` and `/cmd` are dropped at 5.0 s and the slot serves the next request
- urllib login and `/cmd` get correct verdicts
- single segment requests unchanged

The same script run against the firmware before this PR reproduces the original no-op and the reviewer findings (junk executed, overlong split answered `200`). A config upload round trip (single segment, headers then body, cuts inside the opening boundary, the config text and the closing boundary, and three cuts at once) stores an identical config every time, and the firmware upload that installed this build went through `/upload` as before.

Still independent of #329; whichever merges first, the other picks up a small textual conflict in the `/cmd` branch that resolves mechanically.
