### PR TITLE
Makefile: have clean and distclean recurse into the tool directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,13 +103,16 @@ httpd: html_data.h
 $(SUBDIRS):
 	$(MAKE) -C $@
 
-clean:
+clean: $(SUBDIRSCLEAN)
 	-rm -f html_data.c html_data.h $(VERSION_HEADER)
 	-if [ -d $(BUILDDIR) ]; then find $(BUILDDIR) -type f ! -name "*.bin" -delete; fi
 
-distclean:
+distclean: $(SUBDIRSCLEAN)
 	-rm -f html_data.c html_data.h $(VERSION_HEADER)
 	-rm -rf $(BUILDDIR)
+
+$(SUBDIRSCLEAN):
+	$(MAKE) -C $(@:clean=) clean
 
 $(BUILDDIR)/%.rel: %.c | create_build_dir html_data.h
 	$(CC) -MMD $(CC_FLAGS) -o $@ -c $<
@@ -133,7 +136,7 @@ $(BUILDDIR)/rtlplayground-$(FILENAME_EXTENSION).bin: $(BUILDDIR)/rtlplayground.i
 	tools/output/crc_calculator -u $@
 	ln -sf $(MACHINE)/rtlplayground-$(FILENAME_EXTENSION).bin output/rtlplayground.bin
 
-.PHONY: clean all $(SUBDIRS) $(VERSION_HEADER) create_build_dir
+.PHONY: clean distclean all $(SUBDIRS) $(SUBDIRSCLEAN) $(VERSION_HEADER) create_build_dir
 
 .PHONY:
 machine_check:


### PR DESCRIPTION
Fixes #369.

make clean never entered tools/, so tools/output survived every clean and the host tools were not rebuilt afterwards. The SUBDIRSCLEAN variable, which builds the per-directory clean target names for exactly this purpose, was defined but nothing consumed it. clean and distclean now depend on those targets, and one rule runs each subdirectory's own clean, which tools/Makefile already provides.

Checked with sdcc 4.5.0: make clean removes tools/output; the following make rebuilds all five tools and produces an image byte for byte identical to the one built before the clean (same commit, SOURCE_DATE_EPOCH pinned); make distclean removes both tools/output and output/MACHINE; a second clean on an already clean tree exits 0.
