### PR TITLE
Fix VLAN command documenation. 'u'-suffix is not accepted anymore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
   - VLAN don't accept port `u`-suffix anymore.
     So `vlan 1 4u` is not valid anymore.
     Replace it with `vlan 1 4`.
+- Commands
+  - port zero/`0` is treated as the `CPU_PORT`. #326
+  - Many commands don't accept the CPU_PORT anymore. See #334.
+    When the CPU_PORT is needed, the command/service will add the CPU_PORT automaticly.
+    Only `isolate` accept the CPU_PORT as destination port.
 
 ## [v0.1_aplha] - 2025-11-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+
+## [0.x] - 2026-xx-XX
+
+## Added
+
+## Changed
+
+## Fixed
+
+## Breaking changes
+
+- Config
+  - VLAN don't accept port `u`-suffix anymore.
+    So `vlan 1 4u` is not valid anymore.
+    Replace it with `vlan 1 4`.
+
+## [v0.1_aplha] - 2025-11-03
+
+First release.

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -541,7 +541,7 @@ void parse_vlan(void)
 	}
 	return;
 err:
-	print_string("Error: vlan (<vlan-id>|show) [port][t/u]...\n");
+	print_string("Error: vlan (<vlan-id>|show) [port][t]...\n");
 }
 
 

--- a/doc/vlan.md
+++ b/doc/vlan.md
@@ -69,9 +69,9 @@ void vlan_delete(uint16_t vlan) __banked;
 # VLAN configuration on the Serial Console
 For testing the following commands are provided on the serial console:
 ```
-vlan <VLAN-ID> p[t/u]...
-  create or set vlan with given ID and the list of ports as members, a t
-  behind a port defines the port as a tagged member, the u is optional
+vlan <VLAN-ID> p[t]...
+  create or set vlan with given ID and the list of ports as members, a `t`
+  behind a port defines the port as a tagged member.
 
 vlan <VLAN-ID> d
   deletes the VLAN

--- a/html/config.js
+++ b/html/config.js
@@ -10,7 +10,7 @@ const conf_cmds = [
   /^passwd\s+\S+$/,
   /^vlan\s+\d{1,4}\s+d$/,
   /^vlan\s+\d{1,4}\s+mgmt$/,
-  /^vlan\s+\d{1,4}(\s+[a-zA-Z]\w*)?(\s+\d{1,2}[tu]?)+$/,
+  /^vlan\s+\d{1,4}(\s+[a-zA-Z]\w*)?(\s+[1-9]t?)+$/,
   /^pvid\s+\d{1,2}\s+\d{1,4}$/,
   /^ingress(\s+\d{1,2}[tua])+$/,
   /^ingress\s+[tua]$/,


### PR DESCRIPTION
Fix VLAN command documentation.
`u`-suffix is not accepted anymore after #326.
The new parser now checks if a SPACE or `t` is behind the port number.
Old parser did not check this and accepted any character.

Remove the optional `u` from the VLAN documentation and help message.

Fixes #378