### PR TITLE
sfp: stop the web pages printing the previous slot's bytes

### DIFF
--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -178,8 +178,8 @@ void send_sfp_info(uint8_t sfp)
 {
 	// This loops over the Vendor-name, Vendor OUI, Vendor PN and Vendor rev ASCII fields
 	for (uint8_t i = 16; i < 64; i++) {
-		if (!(i & 0xf))
-			sfp_read_block(sfp, i, 16);
+		if (!(i & 0xf) && !sfp_read_block(sfp, i, 16))
+			return;
 		if (i < 20 || i >= 60 || (i >= 36 && i < 40)) // Skip Non-ASCII codes
 			continue;
 		uint8_t c = sfp_buf[i & 0xf];
@@ -195,7 +195,8 @@ void sfp_send_data(uint8_t slot, uint8_t reg, uint8_t len)
 	if (len > 16)
 		return;
 
-	sfp_read_block(slot, reg, len);
+	if (!sfp_read_block(slot, reg, len))
+		return;
 
 	for (uint8_t i = 0; i < len; i++)
 		byte_to_html(sfp_buf[i]);


### PR DESCRIPTION
Fixes #381.

An empty SFP slot used to read back `0xa0` per byte, and the filter in `send_sfp_info()` dropped it, so the field came out empty. Block reads report the failure instead and leave `sfp_buf` holding whatever the last successful read put there, so the two callers in `page_impl.c` that ignore the return print the other slot's bytes. Control characters among them are what makes the JSON non-compliant, which is why the page shows nothing.

Both callers now say nothing when there is nothing to read, which is what the other eight callers of `sfp_read_block()` already do. No unchecked call remains in the tree.

Bank 0 gains 55 bytes against main on SWTGW218AS and SWTG024AS_V2_0, and the build is warning free.
