### PR TITLE
cmd: let "isolate off" put the top port back in the member list

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -573,7 +573,7 @@ void parse_isolate(void)
     }
 
 	if (cmd_compare(2, "off")) {
-		for (uint8_t i = machine.min_port; i < machine.max_port; i++)
+		for (uint8_t i = machine.min_port; i <= machine.max_port; i++)
 			members |= ((uint16_t)1) << i;
 		members |= 0x200; // CPU-port
 		port_isolate(port_configured, members);


### PR DESCRIPTION
Fixes #334 (the second half found while checking the first).

`isolate <port> off` rebuilds the member mask so the port talks to everything again, but the loop stops one short of `machine.max_port`, which is the last port rather than one past it everywhere else in the tree: 24 loops over the range use `<=` and this was the only one that did not. The top front panel port keeps its bit clear and stays isolated.

Measured on a SWTGW218AS before the change:

```
isolate 3 show  ->  1 2 3 4 5 6 7 8 9 CPU
isolate 3 off
isolate 3 show  ->  1 2 3 4 5 6 7 8 CPU
```

Port 9 does not come back until the members are given again by hand.

Bank 0 and the build are unchanged, warning free on SWTGW218AS and SWTG024AS_V2_0.
