### PR TITLE
cmd: keep the history pointer inside the ring

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -1771,7 +1771,8 @@ void cmd_parser(void) __banked
 			// Copy last cmd-buffer to history.
 			cmd_history_ptr = (cmd_history_ptr + i) & CMD_HISTORY_MASK;
 			__xdata uint16_t p = cmd_history_ptr;
-			cmd_history[cmd_history_ptr++] = '\n';
+			cmd_history[cmd_history_ptr] = '\n';
+			cmd_history_ptr = (cmd_history_ptr + 1) & CMD_HISTORY_MASK;
 			do {
 				i--;
 				cmd_history[--p & CMD_HISTORY_MASK] = cmd_buffer[i];


### PR DESCRIPTION
Fixes the hang in #379.

`cmd_history_ptr` is masked when it advances over the command text, then incremented once more for the newline without masking:

```c
cmd_history_ptr = (cmd_history_ptr + i) & CMD_HISTORY_MASK;
cmd_history[cmd_history_ptr++] = '\n';
```

so it can come to rest at `CMD_HISTORY_SIZE`, one past the ring. Both readers start from it and mask their own index every step:

```c
uint16_t p = (cmd_history_ptr + 1) & CMD_HISTORY_MASK;
while (p != cmd_history_ptr) { ... p = (p + 1) & CMD_HISTORY_MASK; }
```

`p` never reaches an index outside the ring, so the walk does not end. `history` on the console spins there, and `send_cmd_log()` does the same while writing `outbuf[slen++]` well past its 2500 bytes.

`flashSave()` in `html/system.js` fetches `/cmd_log` on every save, which is why saving settings is what trips it. Whether the pointer lands one past the end depends on the accumulated length of the commands entered, so it is not deterministic between devices.

Build unchanged and warning free on SWTGW218AS and SWTG024AS_V2_0.
