### PR TITLE
httpd: let the login page fetch its translations

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -994,6 +994,7 @@ void httpd_appcall(void)
 			if (!authenticated && !(f_data[entry].start == FDATA_START_login_html 
 						|| f_data[entry].start == FDATA_START_port_svg 
 						|| f_data[entry].start == FDATA_START_sfp_svg
+						|| f_data[entry].start == FDATA_START_i18n_js
 						|| f_data[entry].start == FDATA_START_style_css)) {
 				send_to_login();
 				goto do_send;


### PR DESCRIPTION
The login page never comes up translated and it took me longer than I'd like to admit to see why. login.html does ask for i18n.js, but that file isn't on the small list of things httpd hands out before you log in, so the request gets the redirect back to login instead. The page then falls back to the English sitting in the markup, whatever your browser asked for.

So it's one line, adding i18n.js to that list. The file only holds the interface strings the page is already showing you in English, so there's nothing in it that isn't on screen anyway.

If you want to see it, point a browser set to a language you have a translation for at the login page. It picks the strings up afterwards.

This fell out of a bigger branch I keep locally, hence the one liner. Happy to move it if you'd rather have it somewhere else.
