### PR TITLE
lag: fix the web page's group numbering, and the command's syntax line

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -406,10 +406,16 @@ void parse_lag(void)
 	if (group > 3)
 		goto err;
 
+	if (cmd_words_len == 2)
+		goto err;
+
+	if (cmd_compare(2, "delete") || cmd_compare(2, "d")) {
+		port_lag_members_set(group, 0);
+		return;
+	}
+
 	uint8_t w = 2;
 	while (w < cmd_words_len) {
-//		write_char('|'); print_byte(w); write_char(':'); write_char(cmd_buffer[cmd_words_b[w]]); write_char('-');
-
 		// Parse port.
 		if (cmd_parse_port_separator(cmd_words_b[w++]) == 0)
 			goto err;
@@ -419,7 +425,7 @@ void parse_lag(void)
 	port_lag_members_set(group, members);
 	return;
 err:
-	print_string("Error: lag <1-4> [port]...\n");
+	print_string("Error: lag (show | <1-4> (delete | <port>...))\n");
 }
 
 

--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -395,7 +395,7 @@ void parse_lag(void)
 		return;
 	}
 
-	if (cmd_words_len < 2)
+	if (cmd_words_len < 3)
 		goto err;
 
 	// Parse group, expect only one number 0-9;
@@ -406,10 +406,7 @@ void parse_lag(void)
 	if (group > 3)
 		goto err;
 
-	if (cmd_words_len == 2)
-		goto err;
-
-	if (cmd_compare(2, "delete") || cmd_compare(2, "d")) {
+	if (cmd_compare(2, "d")) {
 		port_lag_members_set(group, 0);
 		return;
 	}
@@ -425,7 +422,7 @@ void parse_lag(void)
 	port_lag_members_set(group, members);
 	return;
 err:
-	print_string("Error: lag (show | <1-4> (delete | <port>...))\n");
+	print_string("Error: lag (show | <1-4> (d | <port>...))\n");
 }
 
 

--- a/doc/link_aggregation.md
+++ b/doc/link_aggregation.md
@@ -48,9 +48,11 @@ void port_lag_hash_set(__xdata uint8_t lag, __xdata uint8_t hash_bits) __banked;
 ## LAG configuration on the Serial Console
 For testing the following commands are provided on the serial console:
 ```
-> lag <LAG-ID> [p1] [p2]...
-  Create or set a LAG. Trunk-ID is 1 or 2. Ports are physical ports
-  If only the LAG-ID is given but no members, the LAG is deleted
+> lag <LAG-ID> <p1> [p2]...
+  Create or set a LAG. LAG-ID is 1 to 4. Ports are physical ports.
+
+> lag <LAG-ID> d
+  Delete the LAG.
 
 > lag show
   Shows information on all 4 lags

--- a/html/lag.js
+++ b/html/lag.js
@@ -57,7 +57,7 @@ function fetchLag() {
   sendXHTTP(xhttp);
 }
 async function lagSub(l) {
-  var cmd = "lag " + l;
+  var cmd = "lag " + (l + 1);
   for (let i = 1; i <= numPorts; i++) {
     if (document.getElementById("p_mLAG"+l+"_"+i).checked)
       cmd = cmd + ` ${i}`;


### PR DESCRIPTION
Three small things @logicog ran into while testing #397 on a 4+2 board. None of them come from that branch, so they are here instead.

**The web page cannot create the first group.** The LAG page draws four sections headed LAG 1 to LAG 4 and wires their buttons to `lagSub(0)` through `lagSub(3)`, then sends that index straight through as the group number. The first button therefore asks for `lag 0`, the parser rejects it, and nothing appears on the page because the error only reaches the console. The rest are off by one, so the section headed LAG 2 is the one that creates group 1. The index stays 0-based for the element ids; only the command gets the 1-based number.

**The usage line leaves out `show`.** `lag show` is the only way to see the groups, and it is the one subcommand the error message does not mention.

**A group number with no ports silently wiped the group.** Worth having, but not one fat-fingered return away from a bare `lag 1`. It takes `lag 1 delete` or `lag 1 d` now, and a bare group number prints the usage.

Nothing changes for a saved configuration: `lag 1 5 6` is still what gets written and replayed, and neither the old bare form nor the new delete matches the pattern that decides what is persisted.

Builds for SWTGW218AS and `machine_check` is clean. The GUI half I have not clicked through myself, since the board I have puts logical and physical numbering one apart and the bug is invisible there; @logicog, you have the hardware that shows it.
