### PR TITLE
l2: name the group a learned address sits behind

### DIFF
--- a/html/l2.js
+++ b/html/l2.js
@@ -68,7 +68,11 @@ var l2SortCol = 'port';
 var l2SortDir = 1;
 
 function l2Key(e, col) {
-  if (col === 'port') return e.port === 'CPU' ? Number.MAX_SAFE_INTEGER : Number(e.port);
+  if (col === 'port') {
+    if (e.port === 'CPU') return Number.MAX_SAFE_INTEGER;
+    if (e.lag) return 100 + e.lag;
+    return Number(e.port);
+  }
   if (col === 'vlan') return Number(e.vlan);
   return String(e[col]).toLowerCase();
 }
@@ -114,7 +118,11 @@ function fillL2(s)
     return;
   s.sort(l2CMP);
   s = uniq(s);
-  l2All = s;
+  l2All = s.map(function(e) {
+    if (e.lag)
+      e.port = 'LAG' + e.lag;
+    return e;
+  });
   renderL2();
 }
 

--- a/httpd/page_impl.c
+++ b/httpd/page_impl.c
@@ -359,6 +359,7 @@ void send_l2(uint16_t idx)
 	while (1) {
 		entries_left--;
 		uint8_t port = 0;
+		uint8_t lag;
 		reg_read_m(RTL837x_TBL_DATA_0);
 		REG_WRITE(RTL837x_TBL_DATA_0, sfr_data[0], sfr_data[1] & 0xfc, sfr_data[2] | (TBL_LUTREAD_NEXT_L2UC << 6), sfr_data[3]);
 
@@ -402,6 +403,9 @@ void send_l2(uint16_t idx)
 
 			port |= (sfr_data[3] & 0x3) << 2;
 			itoa_html(port);
+			slen += strtox(outbuf + slen, ",\"lag\":");
+			lag = port_lag_of(port);
+			itoa_html(lag == PORT_LAG_NONE ? 0 : lag + 1);
 		}
 
 		// Index

--- a/rtl837x_port.c
+++ b/rtl837x_port.c
@@ -381,6 +381,7 @@ void port_l2_learned(void) __banked
 
 	while (1) {
 		uint8_t port = 0;
+		uint8_t lag;
 		reg_read_m(RTL837x_TBL_DATA_0);
 		REG_WRITE(RTL837x_TBL_DATA_0, sfr_data[0], sfr_data[1],sfr_data[2] | 0xc0, sfr_data[3]);
 
@@ -422,7 +423,13 @@ void port_l2_learned(void) __banked
 				print_string("\tlearned\t");
 
 			port |= (sfr_data[3] & 0x3) << 2;
-			print_phys_port(port);
+			lag = port_lag_of(port);
+			if (lag == PORT_LAG_NONE) {
+				print_phys_port(port);
+			} else {
+				print_string("LAG");
+				itoa(lag + 1);
+			}
 		}
 
 		entry++;


### PR DESCRIPTION
The L2 table shows a device that sits behind an aggregate on whichever member the last frame happened to arrive on, and the hash keeps moving that around. The same address is on port 7 in one refresh and on port 8 in the next. Nothing on the page or the console says those two ports are one link, so what you are looking at reads as an address flapping between ports rather than a LAG doing its job.

Watching a single entry by its table index, on a SWTGW218AS with a two port group:

```
idx=0744  c0:74:2b:fb:16:bc  port 7  ...25 s later...  port 6
```

Same index, same address, same VLAN.

I went looking for a trunk bit in the entry first, because taking this from the silicon would be better than correlating it in software. The three words the firmware reads carry a plain member port and nothing that separates a LAG member from an ordinary port, and across 180 entries the port field never goes above 9, so there is no group id tucked in there either. Whether the chip could be told to learn against the trunk instead I could not find out: our register map describes one of the 32 bits in `L2_CTRL`, so I can neither rule it in nor rule it out.

That leaves doing it where the masks already live. `port_lag_of()` is already there and `port_isolate()` already uses it, so both views ask it instead of growing a second copy of the same formula. The console prints `LAG1` where it used to print the member, and `/l2.json` gains a `"lag"` field next to the port, zero when the port is on its own, which is the shape `/stp.json` already uses. The L2 page reads that field for the port column, and for the filter and the sort as well: showing `LAG1` while a search for `7` still pulled half of one device's addresses out of the group would have been worse than leaving it alone. Groups sort after the physical ports, CPU stays last.

The port stays in the JSON deliberately. Which member a frame came in on is genuinely useful when you are chasing a miscabled link, so the page can show the group without the firmware having thrown the detail away.

On hardware, with the group up:

```
c0:74:2b:fb:16:bc   0x001e   learned   LAG1
c0:74:2b:fb:16:bd   0x0002   learned   LAG1
dc:a6:32:a3:53:af   0x0002   learned   9      <- not in a group
```

The page shows the same thing, and a device that had been moving between two ports now stays on one row.

151 bytes of BANK1, which leaves 1139 free.

