### PR TITLE
ports: read the right link state in the port table

### DIFF
--- a/html/ports.js
+++ b/html/ports.js
@@ -14,15 +14,16 @@ function createPortTable() {
        + '</select>';
       const dSwitch = '<input type="checkbox" id="disable_port" onchange="portOnOff();">'
      for (let i = 1; i <= numPorts; i++) {
-      if (pIsSFP[i-1])
-        continue;
-      console.log("Table row: " + i + "pState: " + pState[i-2]);
       const tr = tbl.insertRow();
       let td = tr.insertCell(); td.appendChild(document.createTextNode(t('common_port') + i));
       let portName = portNames[physToLogPort[i-1]] || '';
       td = tr.insertCell(); td.appendChild(document.createTextNode(portName));
-      td = tr.insertCell(); td.innerHTML = linkText(pState[i] + 1);
+      td = tr.insertCell(); td.innerHTML = linkText(pState[i-1] + 1);
       tr.insertCell(); // filled by devRender()
+      if (pIsSFP[i-1]) {
+        tr.insertCell(); tr.insertCell(); tr.insertCell();
+        continue;
+      }
       td = tr.insertCell(); td.innerHTML = sSelect.replaceAll("speed_sel", "speed_sel_" + i);
       td = tr.insertCell(); td.innerHTML = dSwitch.replaceAll("disable_port", "disable_port_" + i)
 						  .replace("portOnOff()", "portOnOff(" + i + ")");
@@ -67,9 +68,9 @@ function updatePortTable() {
   if (tbl.rows.length <= 2 || !numPorts)
     return;
   for (let i = 1; i <= numPorts ; i++) {
+    tbl.rows[i].cells[2].innerHTML = linkText(pState[i-1]+1);
     if (pIsSFP[i-1])
       continue;
-    tbl.rows[i].cells[2].innerHTML = linkText(pState[i-1]+1);
     if (!clicked[i] && pState[i - 1] < 0) {
       document.getElementById('speed_sel_' + i).disabled = true;
       document.getElementById('disable_port_' + i).checked = true;
@@ -133,8 +134,6 @@ function devRender(entries) {
       perPort[e.port].push(e.mac);
   }
   for (let i = 1; i <= numPorts; i++) {
-    if (pIsSFP[i-1])
-      continue;
     var cell = tbl.rows[i].cells[3];
     var macs = perPort[i] || [];
     if (macs.length == 1) {

--- a/html/ports.js
+++ b/html/ports.js
@@ -14,16 +14,14 @@ function createPortTable() {
        + '</select>';
       const dSwitch = '<input type="checkbox" id="disable_port" onchange="portOnOff();">'
      for (let i = 1; i <= numPorts; i++) {
+      if (pIsSFP[i-1])
+        continue;
       const tr = tbl.insertRow();
       let td = tr.insertCell(); td.appendChild(document.createTextNode(t('common_port') + i));
       let portName = portNames[physToLogPort[i-1]] || '';
       td = tr.insertCell(); td.appendChild(document.createTextNode(portName));
       td = tr.insertCell(); td.innerHTML = linkText(pState[i-1] + 1);
       tr.insertCell(); // filled by devRender()
-      if (pIsSFP[i-1]) {
-        tr.insertCell(); tr.insertCell(); tr.insertCell();
-        continue;
-      }
       td = tr.insertCell(); td.innerHTML = sSelect.replaceAll("speed_sel", "speed_sel_" + i);
       td = tr.insertCell(); td.innerHTML = dSwitch.replaceAll("disable_port", "disable_port_" + i)
 						  .replace("portOnOff()", "portOnOff(" + i + ")");
@@ -68,9 +66,9 @@ function updatePortTable() {
   if (tbl.rows.length <= 2 || !numPorts)
     return;
   for (let i = 1; i <= numPorts ; i++) {
-    tbl.rows[i].cells[2].innerHTML = linkText(pState[i-1]+1);
     if (pIsSFP[i-1])
       continue;
+    tbl.rows[i].cells[2].innerHTML = linkText(pState[i-1]+1);
     if (!clicked[i] && pState[i - 1] < 0) {
       document.getElementById('speed_sel_' + i).disabled = true;
       document.getElementById('disable_port_' + i).checked = true;
@@ -134,6 +132,8 @@ function devRender(entries) {
       perPort[e.port].push(e.mac);
   }
   for (let i = 1; i <= numPorts; i++) {
+    if (pIsSFP[i-1])
+      continue;
     var cell = tbl.rows[i].cells[3];
     var macs = perPort[i] || [];
     if (macs.length == 1) {


### PR DESCRIPTION
`createPortTable()` read `pState[i]` where the array is filled by `portNum - 1`, so each row started out showing the next port's link speed until the first refresh corrected it. On the last copper port that meant showing the uplink's speed.

Running the real `status.json` of a nine port switch through both versions, for the eight copper rows the table draws:

```
expected  7  7  7  1  7  1  7  7
before    7  7  1  7  1  7  7  6
after     7  7  7  1  7  1  7  7
```

The debug line above it goes too, since it printed a third index again (`pState[i-2]`).

This originally also gave the SFP port a row of its own. Per review that half is dropped: leaving modules out is deliberate for now, and being able to force a module's speed belongs in a feature of its own rather than arriving inside a fix.
