### PR TITLE
dhcp: fix transaction-id check so it actually compares

### DIFF
--- a/dhcp.c
+++ b/dhcp.c
@@ -94,7 +94,7 @@ void dhcp_prepare_request(void)
 	DHCP_P->hw_len = 6;
 	DHCP_P->hops = 0;
 
-	DHCP_P->tid = HTONS(dhcp_state.transaction_id);
+	DHCP_P->tid = dhcp_state.transaction_id;
 	DHCP_P->delay = HTONS(0);
 	DHCP_P->flags = 0;
 	// Clear fields client_ip to bootp_file
@@ -300,7 +300,7 @@ void parse_opts(void)
 
 void parse_dhcp(void)
 {
-	if (DHCP_P->tid != HTONS(dhcp_state.transaction_id))
+	if (DHCP_P->tid != dhcp_state.transaction_id)
 		return;
 	if (DHCP_P->cookie[0] != 0x63 || DHCP_P->cookie[1] != 0x82 || DHCP_P->cookie[2] != 0x53 || DHCP_P->cookie[3] != 0x63)
 		return;

--- a/dhcp.c
+++ b/dhcp.c
@@ -300,7 +300,7 @@ void parse_opts(void)
 
 void parse_dhcp(void)
 {
-	if (!DHCP_P->tid == HTONS(dhcp_state.transaction_id))
+	if (DHCP_P->tid != HTONS(dhcp_state.transaction_id))
 		return;
 	if (DHCP_P->cookie[0] != 0x63 || DHCP_P->cookie[1] != 0x82 || DHCP_P->cookie[2] != 0x53 || DHCP_P->cookie[3] != 0x63)
 		return;


### PR DESCRIPTION
`parse_dhcp()` guarded the transaction id with

    if (!DHCP_P->tid == HTONS(dhcp_state.transaction_id))
        return;

Unary `!` binds tighter than `==`, so this is `(!tid) == HTONS(id)`, which
is false for any non-zero id and never returns. The id is never actually
checked, so a DHCP reply for another client on the segment (the socket is
bound broadcast) is parsed as ours: a broadcast OFFER makes us chase
another host's address and a broadcast ACK makes us adopt it.

Compare the field directly. The id is network-order in the packet and
host-order in the state, matching the HTONS() used when the request is
built, so `DHCP_P->tid != HTONS(...)` is the intended test.

Found by inspection while looking at #404; not yet reproduced on hardware.
Builds for all machines (`make machine_check`).
