### PR TITLE
Age the ARP cache by calling uip_arp_timer()

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -89,6 +89,7 @@ volatile __xdata uint32_t ticks;
 volatile __xdata uint8_t sec_counter;
 volatile __xdata uint16_t sleep_ticks;
 __xdata uint8_t stp_clock;
+__xdata uint8_t arp_age_secs;
 extern __xdata struct dhcp_state dhcp_state;
 
 #define STP_TICK_DIVIDER 3
@@ -1565,6 +1566,11 @@ void idle(void)
 
 		// Check for button presses once a second
 		handle_button();
+		// Age the ARP cache: uip_arp_timer() expects a 10 s cadence
+		if (++arp_age_secs >= 10) {
+			arp_age_secs = 0;
+			uip_arp_timer();
+		}
 
 #ifdef DEBUG
 		print_sfr_data();


### PR DESCRIPTION
`uip_arp_timer()` is defined but never called, so the ARP cache is only
refreshed on new learning and only evicted under table pressure. A cached
entry for a peer whose MAC later changes (a gateway failover, a replaced
device) keeps being used until it is evicted, so traffic reached through it
is sent to the old MAC and lost, while on-link traffic is unaffected.

uIP expects the timer roughly every ten seconds; drive it from the
once-per-second housekeeping in `idle()`.

One candidate for the management-plane wedge in #404 (off-subnet dies,
on-subnet keeps working). Builds for all machines (`make machine_check`).
