### PR TITLE
Do not call write_char() from the external interrupt handlers

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -493,7 +493,6 @@ void print_cmd_prompt(void)
 void isr_ext0(void) __interrupt(0)
 {
 	EX0 = 0;	// Disable interrupt for the moment
-	write_char('X');
 	IT0 = 1;	// Trigger on falling edge of external interrupt
 	EX0 = 1;	// Re-enable interrupt
 }
@@ -501,14 +500,11 @@ void isr_ext0(void) __interrupt(0)
 
 /*
  * External IRQ 1 Service Routine, triggered by the NIC recieving a packet
- * Note that all registers are being put on the STACK because of calling
- * a subroutine (write_char), we shold do better...
  */
 void isr_ext1(void) __interrupt(2)
 {
 	// This flag should only be reset after all packets have been read
 	EX1 = 0;
-	write_char('Y');
 	EX1 = 1;
 }
 
@@ -519,7 +515,6 @@ void isr_ext1(void) __interrupt(2)
 void isr_ext2(void) __interrupt(8)
 {
 	EXIF &= 0xef;	// Clear IRQ flag (bit 7) in EXIF
-	write_char('Z');
 	PCON |= 1; // Enter Idle mode until interrupt occurs
 }
 
@@ -530,7 +525,6 @@ void isr_ext2(void) __interrupt(8)
 void isr_ext3(void) __interrupt(9)
 {
 	EXIF &= 0xdf;	// Clear IRQ flag (bit 6) in EXIF
-	write_char('W');
 }
 
 // Timer2: handles system tick.


### PR DESCRIPTION
The EX0..EX3 handlers each emitted a debug character through `write_char()`,
which busy-waits on the serial TX-empty flag set by the serial interrupt.
If one of these runs while a byte is in flight, it waits for a flag the
equal-or-lower-priority serial interrupt cannot deliver, hanging the handler
with the system tick stopped.

The characters were only debug markers, so drop them; the handlers now just
acknowledge the interrupt. No ISR should call the blocking console path.

A latent trap noted while investigating #404 (I could not get these handlers
to fire under load on an RTL8372, so likely not that report's cause, but the
deadlock is real). Builds for all machines (`make machine_check`).
