### PR TITLE
httpd: retransmit a continued chunk from where it was sent

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -865,7 +865,6 @@ void httpd_appcall(void)
 			o_idx += uip_mss();
 		} else {
 			slen = 0;
-			o_idx += slen;
 		}
 
 		s->tstate = TSTATE_ACKED;
@@ -886,7 +885,8 @@ void httpd_appcall(void)
 			flash_region.addr = cont_addr;
 			flash_region.len = slen;
 			flash_read_bulk(outbuf);
-			uip_send(outbuf, slen);
+			o_idx = 0;
+			uip_send(outbuf + o_idx, slen);
 			cont_len -= slen;
 			cont_addr += slen;
 			s->tstate = TSTATE_TX;


### PR DESCRIPTION
Anything larger than the 2500-byte output buffer goes out in two phases. The first buffer is sent in MSS-sized pieces with `o_idx` walking through it, and once that is drained the rest is streamed from flash a chunk at a time into `outbuf`, always from offset 0.

The continuation branch never resets `o_idx`, so it keeps whatever the first phase left there, normally 1460. Meanwhile `uip_rexmit()` retransmits with `uip_send(outbuf + o_idx, slen)`. So when a continuation segment goes missing, what goes out in its place is the bytes 1460 further into the buffer, and the client takes those as the data it was waiting for. With `o_idx + slen` reaching 2920 against a 2500-byte buffer it also reads 420 bytes past `outbuf`, which happens to be where httpd keeps `entry`, `slen`, `o_idx`, `len_left` and `cont_len`.

Nothing complains, because the length is right. The transfer completes, the file is exactly as long as it should be, and only the contents are wrong, so it shows up as mangled JS or CSS rather than as a failed download.

Reproduced on a SWTGW218AS by dropping 15% of the switch's TCP segments at the client. The direction matters: dropping ACKs proves nothing, because then the switch retransmits data the client already has and TCP throws it away as a duplicate. Fetching the 21 kB `i18n.js` eight times each way:

```
before:  7 of 8 corrupted
after:   0 of 8 corrupted
```

Every corrupted copy was exactly 21326 bytes, and the first differing byte landed at 3625, 6545, 6545, 9465, 16765, 18225 and 19685. Those are all the same offset modulo 1460, and that fixed phase inside the chunk is what pointed at the retransmission rather than at the flash reads.

The fix is `o_idx = 0` where the chunk is read in. The `o_idx += slen` sitting right after `slen = 0` went too, since it only ever added zero.

Builds clean, `make machine_check` passes.
