### PR TITLE
httpd: stop a firmware upload at the end of the image area

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -60,7 +60,6 @@ __xdata uint16_t content_length;
 // Global variables holding POST state
 __xdata uint16_t bindex; // Current index into the boundary
 __xdata uint8_t verify_crc;
-__xdata uint32_t max_upload;
 __xdata uint16_t short_parsed;
 
 #define POSTBODY_CMD	1
@@ -529,6 +528,19 @@ uint8_t stream_upload(void)
 			crc16(upload_settings.p + upload_settings.bptr);
 			flash_buf[write_len++] = upload_settings.p[upload_settings.bptr++];
 			if (write_len >= FLASH_PAGE_SIZE) {
+				/* The staged image spans FIRMWARE_UPLOAD_START to twice that,
+				 * the span check_and_flash_update_image() reads back. Nothing
+				 * else bounds uptr: a body whose closing boundary never arrives
+				 * keeps writing, and on a flash exactly this size the address
+				 * wraps onto the running image at zero. */
+				if (uptr >= (uint32_t)FIRMWARE_UPLOAD_START * 2) {
+					print_string("Upload runs past the image area! Aborting.\n");
+					slen = strtox(outbuf, "HTTP/1.1 400 Bad Request\r\nContent-Length: 30\r\n"
+						"Content-Type: text/plain\r\n\r\n"
+						"NO: upload exceeds image area\n");
+					s->tstate = TSTATE_NONE;
+					return 0;
+				}
 				dbg_string("len: "); dbg_short(write_len); dbg_char(' ');
 				dbg_string("CRC16: "); dbg_short(crc_value); dbg_char('\n');
 				if (uptr % FLASH_SECTOR_SIZE == 0) {
@@ -759,7 +771,6 @@ void handle_post(void)
 			config_upload = 0;
 			uptr = FIRMWARE_UPLOAD_START;
 			verify_crc = 1;
-			max_upload = 1024576;
 			pre_acc = 0;
 		} else if (is_word(request_path, "config")) {
 			if (!authenticated) {
@@ -897,21 +908,15 @@ void httpd_appcall(void)
 			reset_chip();
 		}
 	} else if (uip_newdata() && s->tstate == TSTATE_POST) {
-		// Check here maxupload by subtracting uip_len and close socekt if fails!
-		if (max_upload - uip_len > 0) {
-			upload_settings.p = uip_appdata;
-			upload_settings.bptr = 0;
-			upload_settings.plen = uip_len;
-			stream_upload();
-			// A completed part with a built verdict must go out
-			// through the normal TX path
-			if (s->tstate == TSTATE_NONE && slen)
-				goto do_send;
-			write_char('.');
-		} else {
-			send_bad_request();
+		upload_settings.p = uip_appdata;
+		upload_settings.bptr = 0;
+		upload_settings.plen = uip_len;
+		stream_upload();
+		// A completed part with a built verdict must go out
+		// through the normal TX path
+		if (s->tstate == TSTATE_NONE && slen)
 			goto do_send;
-		}
+		write_char('.');
 	} else if (uip_newdata() && s->tstate != TSTATE_TX) {
 		cont_len = 0;
 		dbg_char('<'); dbg_short(uip_len); dbg_char('\n');


### PR DESCRIPTION
The size guard has never actually done anything. `max_upload` gets set once when the upload starts and is never decremented, so `max_upload - uip_len > 0` is a constant sitting well above zero, and since it is unsigned it could not have gone negative even if something had been subtracting from it. The comment right above it admits as much: the check was still to be written.

And nothing else bounds `uptr`. A body whose closing boundary never turns up, or just one bigger than the image area, keeps writing page after page straight past the staging region. On a part exactly twice `FIRMWARE_UPLOAD_START` those writes run off the end of the chip, the SPI address wraps to zero, and a bad upload takes the running firmware with it. Fair warning on that last step: I have only 2 MB parts here, where the overrun lands in unused space, so that bit is address arithmetic rather than something I watched happen.

I put the bound where `uptr` actually moves, in the page-write path, rather than next to the old check on the receiving side. A receive-side test against `uip_len` gets the final segment wrong: it still carries the closing multipart boundary, which counts towards the length but never reaches flash, so a perfectly good image would be refused right at the finish line. Checking just before the page write also has the nice property that nothing has left the area by the time it fires.

The area itself runs from `FIRMWARE_UPLOAD_START` to twice that, the span `check_and_flash_update_image()` reads back and checksums. A half-written image left behind does no harm: boot rejects it on the checksum and erases it.

`max_upload` goes along with the dead check. `verify_crc` stays, since it is what tells a firmware upload apart from a configuration one, and the latter wants no checksum verdict.

Tried it on a SWTGW218AS by posting 614400 bytes into a 524288-byte area:

```
HTTP/1.1 400 Bad Request
NO: upload exceeds image area
```

and the switch was none the worse for it afterwards: same version running, statics still served byte for byte. Builds clean, `make machine_check` passes.
