### PR TITLE
httpd: do not initialise tstate through uip_conn

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -101,10 +101,11 @@ inline uint8_t is_separator(uint8_t c)
 void httpd_init(void) __banked
 {
 	config_upload = 0; // xdata is not zeroed by the startup code
-	__xdata struct httpd_state * __xdata s = &(uip_conn->appstate);
 	// Start listening to port 80
 	uip_listen(HTONS(80));
-	s->tstate = TSTATE_CLOSED;
+	// Not through uip_conn: it only points at a connection while uIP is
+	// handling one, and nothing has set it yet at init time.
+	uip_conns[0].appstate.tstate = TSTATE_CLOSED;
 	fw_reset_pending = 0; // xdata is not zeroed by the startup code
 }
 


### PR DESCRIPTION
`uip_init()` never sets `uip_conn`, and `httpd_init()` runs right after it, so this went through a pointer nothing had assigned yet:

```c
__xdata struct httpd_state * __xdata s = &(uip_conn->appstate);
...
s->tstate = TSTATE_CLOSED;
```

Working out why it has never bitten anyone took a moment. The startup code does clear xdata, whatever the comments beside those lines say (the link pulls in `__mcs51_genXRAMCLEAR`), so `uip_conn` is NULL rather than junk. `appstate` sits 28 bytes into `struct uip_conn`, so the byte lands at xdata 0x1C, and with the current map that is inside the command line buffer, at an offset nothing reads while the line is empty. `cmd_editor_init()` runs later and starts that buffer over anyway.

So nothing is broken today, and that is entirely down to where things happen to sit. It is still a write to an address with nothing to do with the state being set, and it moves the moment the struct grows or the map shifts, at which point it stops being harmless and turns into a genuinely confusing bug.

Addressing slot zero directly says what is meant. It takes the local pointer with it, which is 22 bytes of BANK1 measured across two clean builds.

I left the `TSTATE` macro idea alone: folding the other 36 uses into it is a size change rather than part of this one.

Builds clean, `make machine_check` passes, and the web UI behaves the same on a SWTGW218AS afterwards.
