### PR TITLE
vlan: bound the name table before writing into it

### DIFF
--- a/cmd_parser.c
+++ b/cmd_parser.c
@@ -504,19 +504,29 @@ void parse_vlan(void)
 		}
 
 		uint8_t w = 2;
-		if (cmd_words_len > w && isletter(cmd_buffer[cmd_words_b[w]])) {
+		uint8_t pos = cmd_words_b[w];
+		if (cmd_words_len > w && isletter(cmd_buffer[pos])) {
 			uint8_t i = 0;
-			vlan_name_remove(vlan_settings.vlan);
-			vlan_names[vlan_ptr++] = hex[(vlan_settings.vlan >> 8) & 0xf];
-			vlan_names[vlan_ptr++] = hex[(vlan_settings.vlan >> 4) & 0xf] ;
-			vlan_names[vlan_ptr++] = hex[vlan_settings.vlan & 0xf];
-			while(!cmd_is_space_or_nul(cmd_words_b[w] + i)) {
-				write_char(cmd_buffer[cmd_words_b[w] + i]);
-				vlan_names[vlan_ptr++] = cmd_buffer[cmd_words_b[w] + i++];
+			while (!cmd_is_space_or_nul(pos + i))
+				i++;
+			if (vlan_ptr + i > (VLAN_NAMES_SIZE - 5)) {
+				print_string("VLAN name table full, name ignored\n");
+			} else {
+				vlan_name_remove(vlan_settings.vlan);
+				__xdata uint8_t *vlan_str = &vlan_names[vlan_ptr];
+				*vlan_str++ = hex[(vlan_settings.vlan >> 8) & 0xf];
+				*vlan_str++ = hex[(vlan_settings.vlan >> 4) & 0xf] ;
+				*vlan_str++ = hex[vlan_settings.vlan & 0xf];
+				while(!cmd_is_space_or_nul(pos)) {
+					uint8_t c = cmd_buffer[pos++];
+					write_char(c);
+					*vlan_str++ = c;
+				}
+				*vlan_str++ = ' '; *vlan_str = NUL;
+				vlan_ptr = vlan_str - vlan_names;
+				print_string("<\n");
 			}
-			vlan_names[vlan_ptr++] = ' '; vlan_names[vlan_ptr] = NUL;
 			w++;
-			print_string("<\n");
 		}
 
 		uint8_t ret;


### PR DESCRIPTION
A VLAN name is copied into `vlan_names` with nothing comparing `vlan_ptr` against `VLAN_NAMES_SIZE`. The only limit is the 128-byte command line, so enough named VLANs simply walk off the end of the 1 kB table.

What sits right behind the table is what makes this nastier than a plain overflow. From the map:

```
008A  vlan_names   (1024)
048A  vlan_ptr     <- first thing overwritten
048C  port_names
05AC  cmd_buffer
```

The first casualty is the index driving the write, so once it is clobbered the following bytes land wherever it now points. And since the configuration is replayed at boot, a config file that overflows does it again on every start rather than once when somebody typed it.

So: measure the name first, and refuse it if the three id digits, the name, its separating space and the terminator would not fit.

Two things about where the check sits. It goes before `vlan_name_remove()`, so a name that does not fit cannot take the existing one down with it. And a rejected name does not fail the whole command, the VLAN still gets its ports: dropping the line outright would lose port membership during a config replay, which is a worse outcome than losing a name.

I have not driven a real table overflow on hardware for this one. Doing that on a live switch means writing over `port_names` and `cmd_buffer` to prove a point, and the layout above is already the argument. The build is clean and `make machine_check` passes.
