### PR TITLE
dhcp: do not leave the old socket behind when starting again

### DIFF
--- a/dhcp.c
+++ b/dhcp.c
@@ -341,6 +341,12 @@ void parse_dhcp(void)
 
 void dhcp_start(void) __banked
 {
+	/* Starting twice would leave the first socket bound: uip_udp_new() takes
+	 * the next free slot while the old one keeps port 68, and dhcp_callback()
+	 * matches on that port rather than on the connection, so every leftover
+	 * runs the state machine too and the timers count down once per socket. */
+	if (dhcp_state.state != DHCP_OFF)
+		dhcp_stop();
 	uip_ipaddr(server, 255,255,255,255);
 	dhcp_state.conn = uip_udp_new(&server, HTONS(DHCPC_SERVER_PORT));
 	dhcp_state.current_ip[0] = dhcp_state.current_ip[1] = dhcp_state.current_ip[2] = dhcp_state.current_ip[3] = 0;


### PR DESCRIPTION
`dhcp_start()` never looked at whether DHCP was already running, and `ip dhcp` calls it without stopping first. A second start therefore takes a fresh slot out of `uip_udp_conns` and leaves the previous one bound.

The leaked slot is the smaller half of it. `dhcp_callback()` works out whether a call is meant for it by comparing the local port, not the connection:

```c
if (lport != HTONS(DHCPC_CLIENT_PORT))
    return;
```

and every leftover socket still holds port 68, so each of them runs the state machine on every poll. The timers live in a single shared `dhcp_state`, and the tick path is `--dhcp_state.ticks`, so they count down once per socket: after two starts the retransmit and renewal timing runs at twice the intended rate, after three at three times. That part shows up straight away, long before anyone runs out of the ten slots.

Stopping the old one first is all it needs. `dhcp_stop()` already removes the connection and clears the state, and the state test keeps it away from a connection that was never created, since a failed `uip_udp_new()` returns before the state is set.

I have not exercised this on hardware: `ip dhcp` on a switch that is reachable over a static address is a good way to lose the switch, and the port match and the shared timer are both plain to read. Builds clean and `make machine_check` passes.
