### PR TITLE
syslog: stop the log ring from lapping its reader

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -277,8 +277,19 @@ void write_char(char c)
 	write_char_no_syslog(c);
 
 	if (syslog_state.enabled) {
-		logbuf[syslog_state.writeptr++] = c;
-		syslog_state.writeptr &= (LOGBUF_SIZE - 1);
+		__xdata uint16_t next = (syslog_state.writeptr + 1) & (LOGBUF_SIZE - 1);
+
+		/* The ring is drained once per main loop pass, and a single command
+		 * can print several times its size, so writing on regardless laps
+		 * the reader and the datagram starts mid record. Drop instead, and
+		 * flag a line so the reader empties what is there even if no
+		 * newline has been seen yet. */
+		if (next == syslog_state.readptr) {
+			syslog_state.line_available = 1;
+			return;
+		}
+		logbuf[syslog_state.writeptr] = c;
+		syslog_state.writeptr = next;
 		if (c == '\n')
 			syslog_state.line_available = 1;
 	}


### PR DESCRIPTION
`write_char()` masks `writeptr` and never looks at `readptr`, so once more than `LOGBUF_SIZE` bytes are written between two drains the ring wraps over content that has not been sent yet.

That is not a corner case. The ring is emptied once per main loop pass, a command runs to completion inside a single pass, and a full L2 listing prints well over twice the 512-byte buffer.

Watching it on a SWTGW218AS with a capture on the syslog server: the console printed 1227 bytes in 38 lines, and what arrived was one 174-byte datagram beginning like this:

```
<14>SWTGW218AS 29    0x0002    learned    9
6c:50:4d:50:e8:69    0x0002    learned    9
```

The first line starts at `29`, the tail of a MAC address whose beginning had already been overwritten. The rest of the dump was simply gone.

Drop the character when the ring is full rather than overwriting, so what has been logged stays intact and it is the tail that goes missing. A full ring also flags a line: otherwise a burst with no newline in it would leave the reader waiting on `line_available` forever and syslog would stop for good.

With that in place the same dump comes back as a 525-byte datagram that starts where the listing does:

```
<14>SWTGW218AS     MAC        VLAN    type    port
dc:a6:32:a3:53:af    0x0002    learned    9
```

What is missing now is the end of the listing rather than its beginning, which is the trade worth having.

The dropped bytes are silent, with no marker in the stream. A marker needs a byte of state to remember that something went missing, and that felt like a separate decision rather than part of this fix.

Builds clean, `make machine_check` passes.
