### PR TITLE
phy: advertise half duplex only when half duplex was asked for

### DIFF
--- a/rtl837x_phy.c
+++ b/rtl837x_phy.c
@@ -332,21 +332,25 @@ void phy_set_speed(void) __banked
 		phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_CTRL, 0x2000);	// Clear bit 12: No Autoneg, Set Extended Pages (bit 13)
 		if (phy_settings.speed == PHY_SPEED_10M) {
 			phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_MGBASE_CTRL, 0x6001);
-			if (!phy_settings.duplex)
-				phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, 0x1421);
-			else if (phy_settings.duplex == 1)
-				phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, 0x1441);
+			uint16_t adv10;
+			if (phy_settings.duplex == PHY_DUPLEX_HALF)
+				adv10 = 0x1421;
+			else if (phy_settings.duplex == PHY_DUPLEX_FULL)
+				adv10 = 0x1441;
 			else
-				phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, 0x1461);
+				adv10 = 0x1461;
+			phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, adv10);
 			phy_modify(phy_settings.port, PHY_MMD31, PHY_MMD31_GBCR, 0x0200, 0x0000);
 		} else if (phy_settings.speed == PHY_SPEED_100M) {
 			phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_MGBASE_CTRL, 0x6001);
-			if (!phy_settings.duplex)
-				phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, 0x1481);
-			else if (phy_settings.duplex == 1)
-				phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, 0x1501);
+			uint16_t adv100;
+			if (phy_settings.duplex == PHY_DUPLEX_HALF)
+				adv100 = 0x1481;
+			else if (phy_settings.duplex == PHY_DUPLEX_FULL)
+				adv100 = 0x1501;
 			else
-				phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, 0x1581);
+				adv100 = 0x1581;
+			phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, adv100);
 			phy_modify(phy_settings.port, PHY_MMD31, PHY_MMD31_GBCR, 0x0200, 0x0000);
 		} else {
 			// AN Advertisement Register (MMD 7.0x0010)

--- a/rtl837x_phy.c
+++ b/rtl837x_phy.c
@@ -343,7 +343,7 @@ void phy_set_speed(void) __banked
 			phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_MGBASE_CTRL, 0x6001);
 			if (!phy_settings.duplex)
 				phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, 0x1481);
-			if (phy_settings.duplex == 1)
+			else if (phy_settings.duplex == 1)
 				phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, 0x1501);
 			else
 				phy_write(phy_settings.port, PHY_MMD_AN, PHY_ANEG_ADV, 0x1581);


### PR DESCRIPTION
The 100M branch of `phy_set_speed()` was missing an `else`. A port set to 100M half wrote 0x1481, walked into the next `if`, found duplex was not 1, took its `else` and overwrote the register with 0x1581 straight away, so it ended up advertising 100BASE-TX half and full both.

Bit 7 is 100BASE-TX half and bit 8 is full, which makes 0x1481, 0x1501 and 0x1581 half, full and both, the same shape as 0x1421, 0x1441 and 0x1461 in the 10M branch above.

It matters because forcing half duplex is something people do to match a partner that cannot negotiate. Quietly advertising full as well is the wrong way for that to go wrong: the link comes up looking fine and misbehaves under load.

Both branches now choose the advertisement into a variable and write it once, comparing against the `PHY_DUPLEX_*` names instead of 0, 1 and whatever is left. The same values reach the PHY and BANK2 loses 92 bytes.

Not tried on hardware. Every port here has a link up and setting the speed restarts negotiation, so the argument is the neighbouring branch and the bit assignments rather than a measurement.
