### PR TITLE
dhcp: renew at half the lease when the server omits T1

### DIFF
--- a/dhcp.c
+++ b/dhcp.c
@@ -332,6 +332,18 @@ void parse_dhcp(void)
 		uip_ipaddr(&uip_hostaddr, dhcp_state.current_ip[0], dhcp_state.current_ip[1], dhcp_state.current_ip[2], dhcp_state.current_ip[3]);
 		uip_ipaddr(&uip_draddr, dhcp_state.router[0], dhcp_state.router[1], dhcp_state.router[2], dhcp_state.router[3]);
 		uip_ipaddr(&uip_netmask, dhcp_state.subnet[0], dhcp_state.subnet[1], dhcp_state.subnet[2], dhcp_state.subnet[3]);
+		/* T1 is optional. Without it the renewal time stays zero, which
+		 * makes dhcp_timer zero, and the callback then sends a REQUEST on
+		 * every pass through LEASING: client and server trade REQUEST and
+		 * ACK as fast as the round trip allows. RFC 2131 has the client
+		 * renew at half the lease when the server does not say, and if
+		 * there is no lease either, pick something rather than zero. Only
+		 * filled in when absent, so a server that asks for a short renewal
+		 * still gets it. */
+		if (!dhcp_state.renewal)
+			dhcp_state.renewal = dhcp_state.lease / 2;
+		if (!dhcp_state.renewal)
+			dhcp_state.renewal = 60;
 		dhcp_state.state = DHCP_LEASING;
 		dhcp_state.ticks = SYS_TICK_HZ;
 		dhcp_state.dhcp_timer = dhcp_state.renewal > 0xffff ? 0xffff : dhcp_state.renewal;


### PR DESCRIPTION
Option 58 is optional, and `dhcp_state.renewal` is only ever written by `parse_opts()`, so a server that leaves it out keeps it at zero. The ACK handler then does:

```c
dhcp_state.dhcp_timer = dhcp_state.renewal > 0xffff ? 0xffff : dhcp_state.renewal;
```

which is zero, and the callback reads a zero timer in `DHCP_LEASING` as "time to renew", so it sends a REQUEST on the next pass.

The REQUEST itself does set a 30 second timeout, so on its own it would settle down. What keeps it going is the answer: the ACK comes back through the same handler, sets the timer to zero again, and the next pass sends another REQUEST. The two sides then trade REQUEST and ACK as fast as the round trip allows, and the console prints the address, netmask, gateway and lease on every one of them.

RFC 2131 has the client renew at half the lease when the server does not say, so use that, and fall back to a fixed value if the lease is missing too.

Both only fill in a value that is not there. A server that deliberately asks for a short renewal still gets exactly what it asked for, which a plain lower bound would have quietly overridden.

I have not reproduced this: it needs a server configured without the option, and the switch here is on a static address. The chain is short enough to follow in the two functions above.

Builds clean, `make machine_check` passes.
