### PR TITLE
crc16: leave the code bank as it was found

### DIFF
--- a/crc16.asm
+++ b/crc16.asm
@@ -3,6 +3,8 @@
 ;
 	.globl 	_crc_value
 	.globl 	_crc16
+	.globl 	_crc16_bank1
+	.globl 	__sdcc_banked_ret
 	.equ	BANK, 0x96
 ;	.equ	DPS, 0x86
 ; Variable in XMEM holding current CRC16 value, being updated
@@ -18,7 +20,7 @@ _crc_value::
 	.area HOME    (CODE)
 	.area CSEG    (CODE)
 ;	.area BANK1   (CODE)
-_crc16:
+_crc16_bank1:
 	mov	BANK, #1
 	push	dph
 	push	dpl
@@ -51,6 +53,10 @@ _crc16:
 	ret
 
 	.area BANK1   (CODE)
+
+_crc16:
+	lcall	_crc16_bank1
+	ljmp	__sdcc_banked_ret
 
 crc16_table_l:
 	.byte #0x00, #0xc1, #0x81, #0x40, #0x01, #0xc0, #0x80, #0x41

--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -89,7 +89,7 @@ __xdata uint32_t last_session_use;
 
 extern __xdata uint16_t crc_value;
 __xdata uint16_t crc_final;
-void crc16(__xdata uint8_t *v) __naked;
+void crc16_bank1(__xdata uint8_t *v) __naked;
 
 
 inline uint8_t is_separator(uint8_t c)
@@ -518,7 +518,7 @@ uint8_t stream_upload(void)
 		if (upload_settings.p[upload_settings.bptr] == boundary[bindex]) {
 			if (!bindex)
 				crc_final = crc_value;
-			crc16(upload_settings.p + upload_settings.bptr);
+			crc16_bank1(upload_settings.p + upload_settings.bptr);
 			upload_settings.bptr++;
 			bindex++;
 		} else {
@@ -527,7 +527,7 @@ uint8_t stream_upload(void)
 				write_len += bindex;
 				bindex = 0;
 			}
-			crc16(upload_settings.p + upload_settings.bptr);
+			crc16_bank1(upload_settings.p + upload_settings.bptr);
 			flash_buf[write_len++] = upload_settings.p[upload_settings.bptr++];
 			if (write_len >= FLASH_PAGE_SIZE) {
 				dbg_string("len: "); dbg_short(write_len); dbg_char(' ');

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -32,7 +32,7 @@ extern __xdata uint32_t flash_size;
 
 extern __xdata uint16_t crc_value;
 __xdata struct machine_runtime machine_detected;
-void crc16(__xdata uint8_t *v) __naked;
+void crc16_bank1(__xdata uint8_t *v) __naked;
 void flash_default_config(void);
 void early_boot_handle_button(void);
 
@@ -2095,7 +2095,7 @@ void check_and_flash_update_image(void)
 			flash_read_bulk(flash_buf);
 			bptr = flash_buf;
 			for (j = 0; j < FLASH_BUF_SIZE; j++) {
-				crc16(bptr++);
+				crc16_bank1(bptr++);
 			}
 			source += FLASH_BUF_SIZE;
 			if (i%16 == 0) write_char('.');


### PR DESCRIPTION
The lookup tables live in BANK1, so `crc16` switches the code bank to reach them with `movc`, and then never switches it back.

The routine itself sits in the common segment, which is always mapped, so the call always works. The return is where it shows: that lands in whatever bank the caller runs from, and the window is now BANK1 regardless of what the caller had.

Both callers survive it today, by luck rather than design. One is in the common segment, where the window does not matter, and the other is in BANK1, which happens to be exactly what is left selected. Move either of them to another bank, which is an ordinary thing to do when a bank fills up, and the return goes to the right address in the wrong window: the caller carries on executing whatever happens to sit there in BANK1.

Save the bank and put it back. `push` and `pop` on a direct address cost four bytes of the common segment, and the trap stops waiting for the next reshuffle.

Verified where it counts, since both call sites run the checksum over a whole image. Uploading firmware to a switch running this answered `OK: checksum verified`, which is the BANK1 caller, and the boot that followed re-checksummed the staged image from the common segment and applied it, which is the other one. Builds clean, `make machine_check` passes.
