### PR TITLE
fileadder: track the data length instead of measuring it with strlen

### DIFF
--- a/tools/fileadder.c
+++ b/tools/fileadder.c
@@ -173,17 +173,17 @@ int addidx(const char *name, int addr, int len)
 /*
  * Replaces calls of the type #{function} in .html files being added
  * It is assumed that the possibly expanded string will fit into the buffer
- * Returns the new length of the string
+ * Takes the length of the data and returns its new length
  */
-int replaceCalls(int pos)
+int replaceCalls(int pos, int len)
 {
 	int i = 0;
 	char function_buf[256];
 
-	while (buffer[pos + i]) {
-		if ((buffer[pos + i]) == '#' && (buffer[pos + i + 1] == '{')) {
+	while (i < len) {
+		if (buffer[pos + i] == '#' && i + 1 < len && buffer[pos + i + 1] == '{') {
 			int j = 2;
-			while (buffer[pos + i + j]) {
+			while (i + j < len) {
 				if (buffer[pos + i + j] == '}')
 					break;
 				function_buf[j - 2] = buffer[pos + i + j];
@@ -196,12 +196,13 @@ int replaceCalls(int pos)
 
 			}
 			function_buf[j - 2] = '\0';
-			if (!buffer[pos + i + j])
-				return i + j;
+			if (i + j >= len)
+				return len;
 			// Because the buffers overlap we cannot use strcpy
-			memmove(&buffer[pos + i + 5], &buffer[pos + i + j], strlen(&buffer[pos + i + j]) + 1);
+			memmove(&buffer[pos + i + 5], &buffer[pos + i + j], len - (i + j));
 			sprintf(&buffer[pos + i + 2], "%03d", callNum);
 			buffer[pos + i + 5] = '}';
+			len -= j - 5;
 			i += 6;
 			fbuf_p += snprintf(&fbuf[fbuf_p], DEF_SIZE - fbuf_p, "  %s,\n", function_buf);
 			xbuf_p += snprintf(&xbuf[xbuf_p], DEF_SIZE - xbuf_p, "extern uint16_t %s(void);\n", function_buf);
@@ -210,7 +211,7 @@ int replaceCalls(int pos)
 		i++;
 	}
 
-	return strlen(&buffer[pos]);
+	return len;
 }
 
 
@@ -308,6 +309,7 @@ int main(int argc, char **argv)
 				continue;
 
 			size_t data_read = addfile(pathbuffer, addr);
+			size_t file_len = data_read;
 			if (data_read) {
 				if (arguments.add_zero) {
 					buffer[addr + data_read + 1] = '\0';
@@ -316,7 +318,7 @@ int main(int argc, char **argv)
 				printf("Data inserted from %s at 0x%x, size: %ld\n", pathbuffer, addr, data_read);
 			}
 			int old_len = data_read;
-			data_read = replaceCalls(addr);
+			data_read = replaceCalls(addr, file_len);
 			if (old_len > data_read)
 				memset(buffer + addr + data_read, 0, old_len - data_read);
 			addidx(in_file->d_name, addr, data_read);


### PR DESCRIPTION
`replaceCalls()` ends with `strlen(&buffer[pos])`, so the length recorded for a file is the distance to its first `0x00` byte rather than the size of the file. It gets the right answer today only because the byte just past the content happens to be zero.

Nothing in `html/` contains a zero byte at the moment, so this is latent. It is a trap waiting for the first compressed or binary asset, though, and gzip is the obvious candidate: its fourth header byte is part of the mtime field and is usually zero.

What that looks like, with two gzipped files dropped into `html/`:

```
one.css.gz   start 0x40000  index     3 B  actual  1359 B
two.js.gz    start 0x40003  index     3 B  actual  3052 B
```

Both are recorded as three bytes. `addr` advances by the recorded length, so the second file is placed three bytes into the first and overwrites 1356 bytes of it. Nothing warns; the image simply comes out wrong.

After:

```
one.css.gz   start 0x40000  index  1359 B  actual  1359 B
two.js.gz    start 0x4054f  index  3052 B  actual  3052 B
```

The fix is to pass the length in and return the adjusted one rather than measure it. The substitution rewrites `#{function}` as `#{NNN}`, so the change in length is known from `j` and does not need to be measured at all. Bounding the loops by the length rather than by a terminator also covers `-n`, where nothing had put a terminator in the buffer for `strlen` to find in the first place.

Worth saying that the substitution machinery is dormant: no file in `html/` uses `#{...}`, and the generated header declares no functions. So `replaceCalls` currently does nothing except measure, which is what made this safe to verify by comparison.

That comparison is the check I leaned on. Building the same commit before and after, with the version string pinned so it does not colour the result, gives a byte-for-byte identical `.bin` and an identical `html_data.h`. `make machine_check` passes and the tool builds clean under `-Wall`.
