### PR TITLE
Do not enter Idle mode from the external interrupt 2 handler

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -515,7 +515,7 @@ void isr_ext1(void) __interrupt(2)
  */
 void isr_ext2(void) __interrupt(8)
 {
-	EXIF &= 0xef;	// Clear IRQ flag IE2 (bit 4) in EXIF
+	EXIF &= 0xef;
 }
 
 /*
@@ -524,7 +524,7 @@ void isr_ext2(void) __interrupt(8)
  */
 void isr_ext3(void) __interrupt(9)
 {
-	EXIF &= 0xdf;	// Clear IRQ flag IE3 (bit 5) in EXIF
+	EXIF &= 0xdf;
 }
 
 // Timer2: handles system tick.

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -516,7 +516,6 @@ void isr_ext1(void) __interrupt(2)
 void isr_ext2(void) __interrupt(8)
 {
 	EXIF &= 0xef;	// Clear IRQ flag (bit 7) in EXIF
-	PCON |= 1; // Enter Idle mode until interrupt occurs
 }
 
 /*

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -515,7 +515,7 @@ void isr_ext1(void) __interrupt(2)
  */
 void isr_ext2(void) __interrupt(8)
 {
-	EXIF &= 0xef;
+	EXIF &= 0xef;	// Clear IRQ flag (bit 4) in EXIF
 }
 
 /*
@@ -524,7 +524,7 @@ void isr_ext2(void) __interrupt(8)
  */
 void isr_ext3(void) __interrupt(9)
 {
-	EXIF &= 0xdf;
+	EXIF &= 0xdf;	// Clear IRQ flag (bit 5) in EXIF
 }
 
 // Timer2: handles system tick.

--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -515,7 +515,7 @@ void isr_ext1(void) __interrupt(2)
  */
 void isr_ext2(void) __interrupt(8)
 {
-	EXIF &= 0xef;	// Clear IRQ flag (bit 7) in EXIF
+	EXIF &= 0xef;	// Clear IRQ flag IE2 (bit 4) in EXIF
 }
 
 /*
@@ -524,7 +524,7 @@ void isr_ext2(void) __interrupt(8)
  */
 void isr_ext3(void) __interrupt(9)
 {
-	EXIF &= 0xdf;	// Clear IRQ flag (bit 6) in EXIF
+	EXIF &= 0xdf;	// Clear IRQ flag IE3 (bit 5) in EXIF
 }
 
 // Timer2: handles system tick.


### PR DESCRIPTION
`isr_ext2()` ends by putting the core to sleep:

```c
void isr_ext2(void) __interrupt(8)
{
	EXIF &= 0xef;	// Clear IRQ flag (bit 7) in EXIF
	PCON |= 1; // Enter Idle mode until interrupt occurs
}
```

On the DW8051 idle ends when any enabled interrupt is activated, so the core does not stay down for long. The handler naps until the next enabled interrupt request turns up, which the 200 Hz tick caps at 5 ms, and then carries on at the instruction after the sleep. That instruction is the return:

```
_isr_ext2:
	anl	_EXIF,#0xef
	orl	_PCON,#0x01
	reti
```

So the sleep gains nothing, and for as long as it lasts the handler holds the priority latch, leaving everything at its level or below waiting behind it, the tick and the console and the NIC receive interrupt included.

The other four uses of `PCON |= 1` are in task context, in the main loop and the delay helpers, which is the ordinary way to use it. This one is the only one inside a handler.

The bit numbers in the two comments beside the masks are corrected on the way past: `0xef` clears bit 4 and `0xdf` clears bit 5, not 7 and 6.

I have not seen EX2 trigger and cannot tell from the source whether it does: the enable is a bare `EX2 = 1` and nothing describes what drives it.
