### PR TITLE
Refresh ARP entries from incoming IP traffic

### DIFF
--- a/rtlplayground.c
+++ b/rtlplayground.c
@@ -1252,7 +1252,7 @@ void handle_rx(void)
 			}
 		} else if (ETH_IN->ether_type == HTONS(0x0800)) { // IPv4
 			if (!management_vlan || management_vlan == rx_packet_vlan) {
-				uip_arp_ipin();	// Learn MAC addresses in TCP packets
+				uip_arp_ipin();
 				uip_input();
 				if (uip_len) {
 					// Add ethernet frame

--- a/uip/uip_arp.c
+++ b/uip/uip_arp.c
@@ -239,12 +239,9 @@ uip_arp_update(__xdata u16_t * __xdata ipaddr, __xdata struct uip_eth_addr * __x
  * variable uip_len.
  */
 /*-----------------------------------------------------------------------------------*/
-#if 0
 void
-uip_arp_ipin(void)
+uip_arp_ipin(void) __banked
 {
-  uip_len -= sizeof(struct uip_eth_hdr);
-	
   /* Only insert/update an entry if the source IP address of the
      incoming IP packet comes from a host on the local network. */
   if((IPBUF->srcipaddr[0] & uip_netmask[0]) !=
@@ -259,7 +256,6 @@ uip_arp_ipin(void)
   
   return;
 }
-#endif /* 0 */
 /*-----------------------------------------------------------------------------------*/
 /**
  * ARP processing for incoming ARP packets.

--- a/uip/uip_arp.c
+++ b/uip/uip_arp.c
@@ -252,7 +252,7 @@ uip_arp_ipin(void) __banked
      (uip_hostaddr[1] & uip_netmask[1])) {
     return;
   }
-  uip_arp_update(IPBUF->srcipaddr, &(IPBUF->ethhdr.src));
+  uip_arp_update(IPBUF->srcipaddr, &(BUF->ethhdr.src));
   
   return;
 }

--- a/uip/uip_arp.h
+++ b/uip/uip_arp.h
@@ -78,8 +78,7 @@ void uip_arp_init(void) __banked;
    inserts a new mapping if none exists. The function assumes that an
    IP packet with an Ethernet header is present in the uip_buf buffer
    and that the length of the packet is in the uip_len variable. */
-/*void uip_arp_ipin(void);*/
-#define uip_arp_ipin()
+void uip_arp_ipin(void) __banked;
 
 /* The uip_arp_arpin() should be called when an ARP packet is received
    by the Ethernet driver. This function also assumes that the


### PR DESCRIPTION
`uip_arp_ipin()` is an empty macro with its body under `#if 0`, both inherited from the uIP import in `e486c04` and untouched since. That leaves `uip_arp_update()` reachable only from `uip_arp_arpin()`, so an entry is refreshed only by ARP addressed to us and ages out after `UIP_ARP_MAXAGE` no matter how much traffic passed over it. With the ten second timer that is twenty minutes.

When the entry goes, the next transmission to that host walks into the miss path of `uip_arp_out()`, which overwrites the packet sitting in `uip_buf` with an ARP request and returns. The packet is gone.

For TCP that costs a retransmission. The case worth caring about is UDP: `handle_tx()` sends the UDP connections through `uip_arp_out()` as well and nothing retransmits those, so the datagram is simply lost. Syslog to a collector is the shape this bites, since a collector never sends anything back and so nothing ever refreshes its entry. A peer that does its own neighbour probing keeps its entry alive as a side effect, which is probably why this has gone unnoticed.

The body is nearly right as it stands, but it cannot be enabled as written:

```c
uip_len -= sizeof(struct uip_eth_hdr);
```

That is a leftover from when `UIP_LLH_LEN` was zero. Here it is `ETHER_HEADER_SIZE + RTL_FRAME_DESC_SIZE` and `uip.c` reads the IP header at `uip_buf[UIP_LLH_LEN]`, so `uip_len` has to keep the link layer in it; subtracting it before `uip_input()` would break reception. The rest is sound. The netmask test is what keeps us from recording a remote address against the router's MAC, and `uip_netmask` is set both from the configuration and from DHCP.

So: a real prototype in place of the empty macro, the body enabled without that line, and the comment at the call site dropped, since it said TCP and this covers all IP.

110 bytes of BANK1 and 9 of the common segment, BANK2 unchanged, `make machine_check` passes. It does cost a walk of the eight entry table per received IP packet, though only for packets that reach the management path.
