### PR TITLE
igmp: mask the port number before shifting by it

### DIFF
--- a/rtl837x_igmp.c
+++ b/rtl837x_igmp.c
@@ -295,7 +295,7 @@ void igmp_packet_handler(void) __banked
 			entry.pmask |= ((uint16_t)sfr_data[3]) << 2;
 		}
 		// Update (found) entry with portmask from trapped Packet
-		entry.pmask |= (1L << (IGMP_I->rtl_tag.pmask >> 8));  // Swap bytes from network order, only 4 LSB count
+		entry.pmask |= ((uint16_t)1) << ((IGMP_I->rtl_tag.pmask >> 8) & 0x0f);  // Swap bytes from network order, only 4 LSB count
 //		print_string("\nPort-Mask: "); print_short(entry.pmask); write_char('\n');
 	} else if (IGMP_I->igmp_rtype == 0x3){  // Leave group
 		if (sfr_data[2] & 0x10) {
@@ -312,7 +312,7 @@ void igmp_packet_handler(void) __banked
 			write_char('\n');
 #endif
 			// Remove portmask of IGMP packet from entry
-			entry.pmask &= ~(1L << (IGMP_I->rtl_tag.pmask >> 8));  // Swap bytes from network order, only 4 LSB count
+			entry.pmask &= ~(((uint16_t)1) << ((IGMP_I->rtl_tag.pmask >> 8) & 0x0f));  // Swap bytes from network order, only 4 LSB count
 //			print_string("\nPort-Mask: "); print_short(entry.pmask); write_char('\n');
 		} else {
 			print_string("IGMP Entry already deleted\n");


### PR DESCRIPTION
The RTL tag carries a four bit port number on frames coming in, and the two places that turn it into a mask bit use the whole byte:

```c
entry.pmask |= (1L << (IGMP_I->rtl_tag.pmask >> 8));
```

The comment right beside it says only the low four bits count. Nothing takes them, though. The same field comes out of the same tag over in `rtl837x_stp.c:424`, and there it is masked:

```c
stp_scratch = ((uint8_t)HTONS(STP_I->rtl_tag.pmask)) & 0x0f;
```

I had a look at what SDCC makes of it, because reading the C on its own made it sound worse than it turns out to be. The `1L` gets narrowed to sixteen bits and the shift comes out as a `djnz` loop over an eight bit count, so nothing undefined happens. What happens instead is that a count above fifteen spins the loop that many times and leaves zero behind. A join then adds no port, a leave clears none, and neither says a word about it. The spare turns are spent inside packet handling.

Masking to four bits and shifting a `uint16_t` lines this up with the STP side and keeps the loop to fifteen turns at most. Six bytes of BANK1, and all 34 machines in machine.h still build and link.

I should say that this does not get snooping working by itself. `struct igmp_pkt` has no `vlan_tag` in it, while `struct eth_in` describes the same frame and does, so everything below `rtl_tag` is read four bytes early. That is a separate problem and I have not touched it here.
