### PR TITLE
httpd: count every authenticated request as session activity

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -76,7 +76,6 @@ __xdata uint8_t fw_reset_pending;
 __xdata char session_id[SESSION_ID_LENGTH + 1];
 __xdata uint8_t authenticated;
 __xdata uint32_t now;
-__xdata uint8_t * __xdata timeptr;
 __xdata uint32_t last_session_use;
 
 #define TSTATE_NONE		0
@@ -345,9 +344,10 @@ __xdata uint8_t *scan_header(__xdata uint8_t * __xdata p)
 		if (now - last_session_use > SESSION_TIMEOUT) {
 			dbg_string("Session expired\n");
 		} else {
-			if (is_word_x(session, session_id))
+			if (is_word_x(session, session_id)) {
 				authenticated = 1;
-			else
+				last_session_use = now;
+			} else
 				dbg_string("Invalid session cookie!\n");
 		}
 	}
@@ -1018,11 +1018,6 @@ void httpd_appcall(void)
 				send_to_login();
 				goto do_send;
 			}
-			// A web-page is actively accessed, we can reset session time-out
-			reg_read_m(RTL837X_REG_SEC_COUNTER);
-			timeptr = (uint8_t*)&last_session_use; // last_session_use is Little endian
-			timeptr[0] = sfr_data[3]; timeptr[1] = sfr_data[2]; timeptr[2] = sfr_data[1]; timeptr[3] = sfr_data[0];
-
 			slen = strtox(outbuf, "HTTP/1.1 200 OK\r\nContent-Type: ");
 			slen += strtox(outbuf + slen, mime_strings[f_data[entry].mime]);
 			/* 'unsafe-inline' is needed for the inline onclick handlers


### PR DESCRIPTION
The session timer was refreshed in two places only: at login, and when a page from the file table was served. Every JSON endpoint and `/cmd` left it alone. With the old multi-page UI that was invisible, because each navigation loaded a page. With the single-page UI from #315 the pages are fetched once and everything after that is JSON, so the session expires `SESSION_TIMEOUT` (200) seconds after the page load however busy the user is, and the next request is answered with 401. A firmware upload started after that point gets the 401 instead of a checksum verdict, which is how I ran into it.

The change refreshes the timer wherever the session cookie validates in `scan_header()`, which covers every authenticated request, and drops the page-serving refresh that this makes redundant, together with the `timeptr` scratch pointer it used. Three lines in, seven out.

Measured on `PCB_SWTG018AS_V2_1_0`: internal RAM map identical to `main`, BANK1 66 bytes smaller, xdata 2 bytes smaller, `make machine_check` clean. On the switch: after login, polling `/information.json` every 30 s stays authenticated past 240 s; before the change the same probe was logged out at 210 s. Unauthenticated requests still get their 401.
