### PR TITLE
stat: do not fetch the port status twice when opening the page

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -1746,7 +1746,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
 sectionInits.stat = function() {
   update( () => {
-    update();
     fillStats();
     setSectionInterval(fillStats, 1000);
     setSectionInterval(update, 2000);


### PR DESCRIPTION
Opening the statistics page asks for /status.json twice: `sectionInits.stat`
calls `update()`, and its callback calls `update()` again. The second reply is
not used.

Dropping the inner call is enough, since the callback already runs once the
first reply has been parsed.
