### PR TITLE
l2: stop the FDB walk when its section is left

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -932,6 +932,7 @@ document.addEventListener('DOMContentLoaded', function() {
  * shown.  Each section initialises on first display, and its polling
  * intervals run only while the section is visible. */
 var sectionIntervals = [];
+var l2WalkGen = 0;
 var sectionInits = {};
 
 function setSectionInterval(fn, ms) {
@@ -951,6 +952,7 @@ function clearSectionIntervals() {
     clearTimeout(devTimer);
     devTimer = null;
   }
+  l2WalkGen++;
 }
 
 function showSection(name) {
@@ -2780,10 +2782,11 @@ function walkL2(onDone)
   var entries = [];
   var idx = 0;
   var tries = 0;
+  var gen = l2WalkGen;
 
   function retry() {
     if (++tries < 3) {
-      setTimeout(page, 1000);
+      setTimeout(function() { if (gen === l2WalkGen) page(); }, 1000);
       return;
     }
     onDone(entries, false);
@@ -2828,7 +2831,7 @@ function walkL2(onDone)
         return;
       }
       idx = s[s.length - 1].idx + 1;
-      setTimeout(page, 1000);
+      setTimeout(function() { if (gen === l2WalkGen) page(); }, 1000);
     };
     xhttp.open("GET", "/l2.json?idx=" + idx, true);
     xhttp.timeout = 1500;


### PR DESCRIPTION
`walkL2()` reads the forwarding database a page at a time, asking for the next
page from `setTimeout(page, 1000)`. If the user moves to another section while
a walk is in progress, the walk carries on. `devWalk()` does check that the
ports section is still visible, but that check sits on the 15 s restart of the
whole walk rather than on the paging inside one.

This is an easy one to miss: `clearSectionIntervals()` clears
`sectionIntervals`, `l2Timer` and `devTimer`, and reads as though it covers
everything. The paging timer simply is not registered with it.

The patch gives `walkL2` a generation number that `clearSectionIntervals()`
bumps, and both timers check it before asking for the next page.

It matters more on a larger table than on mine: the paging accepts up to 4096
entries, so a walk can run to about 146 requests at one per second on a page
that has no use for them.
