### PR TITLE
Fix Github Build - Add zlib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt update
-          apt install make gcc sdcc xxd python-is-python3 libjson-c-dev -y
+          apt install make gcc sdcc xxd python-is-python3 libjson-c-dev zlib1g-dev -y
       - name: Check if machine.c can be compiled for all machines
         run: make machine_check
       - name: Make project

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ device simulator is provided, which runs entirely under Linux as a local webserv
 Install the following particular build requisites (Debian 12/13), note that Ubuntu 24.04
 still has an older version of sdcc, but you will need sdcc version 4.5 for the code to compile:
 ```
-sudo apt install make gcc sdcc xxd python-is-python3 libjson-c-dev
+sudo apt install make gcc sdcc xxd python-is-python3 libjson-c-dev zlib1g-dev
 ```
 
 <details>
@@ -175,7 +175,7 @@ Header checksum is: 0x5a1
 ## (3) Sandbox Usage with Ghidra (optional)
 
 You can play with the image using ghidra or flash real Switch Hardware. For
-ghidra see this information about [Ghidra images](ghidra.md).
+ghidra see this information about [Ghidra images](doc/ghidra.md).
 
 ## (4) Installation through the Web interface (software way)
 


### PR DESCRIPTION
The fileadder in https://github.com/logicog/RTLPlayground/pull/315 requires zlib.h to build so we we're getting:
```
gcc injector.c -Wall -o output/injector
gcc fileadder.c -Wall -o output/fileadder -lz
fileadder.c:14:10: fatal error: zlib.h: No such file or directory
   14 | #include <zlib.h>
      |          ^~~~~~~~
compilation terminated.
make[1]: *** [Makefile:18: output/fileadder] Error 1
make[1]: Leaving directory '/__w/RTLPlayground/RTLPlayground/tools'
make: *** [Makefile:114: tools] Error 2
```

in the GH action